### PR TITLE
Radios to checkboxes in dialogs

### DIFF
--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -64,7 +64,7 @@
 <group>
 	<layout>hbox</layout>
 	<padding>6</padding>
-	<radio>
+	<checkbox>
                 <halign>left</halign>
                 <label>add/ remove nose wheel fairing</label>
                 <property>/sim/model/c182s/nw_fairing</property>
@@ -76,11 +76,11 @@
 	<binding>
                     <command>dialog-update</command><!-- makes sure that command is still there when dialog is closed-->
                 </binding>
-	</radio>
+	</checkbox>
 
 	
 
-	<radio>
+	<checkbox>
                 <halign>right</halign>
                 <label>add/ remove main wheels fairing</label>
                 <property>/sim/model/c182s/mw_fairing</property>
@@ -92,7 +92,7 @@
 	<binding>
                     <command>dialog-update</command><!-- makes sure that command is still there when dialog is closed-->
                 </binding>
-	</radio>
+	</checkbox>
         </group>
 	<hrule/>
 	

--- a/gui/dialogs/securing.xml
+++ b/gui/dialogs/securing.xml
@@ -47,7 +47,7 @@
 <group>
 	<layout>hbox</layout>
 	<padding>6</padding>
-	<radio>
+	<checkbox>
                 <halign>left</halign>
                 <label>Place nose wheel chock</label>
                         <live>true</live>
@@ -65,9 +65,9 @@
 	<binding>
                     <command>dialog-update</command><!--do not use dialog-apply - bad interactions with walker!-->
                 </binding>
-	</radio>
+	</checkbox>
 	
-<radio>
+<checkbox>
                 <halign>center</halign>
                 <label>Place left wheel chock</label>
                         <live>true</live>
@@ -85,9 +85,9 @@
 	<binding>
                     <command>dialog-update</command><!--do not use dialog-apply - bad interactions with walker!-->
                 </binding>
-	</radio>
+	</checkbox>
 	
-<radio>
+<checkbox>
                 <halign>right</halign>
                 <label>Place right wheel chock</label>
                         <live>true</live>
@@ -105,7 +105,7 @@
 	<binding>
                     <command>dialog-update</command><!--do not use dialog-apply - bad interactions with walker!-->
                 </binding>
-	</radio>
+	</checkbox>
 	
         </group>
 
@@ -113,7 +113,7 @@
 <group>
 	<layout>hbox</layout>
 	<padding>6</padding>
-	<radio>
+	<checkbox>
                 <halign>right</halign>
                 <label>Place right safety cone</label>
                         <live>true</live>
@@ -131,9 +131,9 @@
 	<binding>
                     <command>dialog-update</command>
                 </binding>
-	</radio>
+	</checkbox>
 	
-<radio>
+<checkbox>
                 <halign>left</halign>
                 <label>Place left safety cone</label>
                         <live>true</live>
@@ -151,7 +151,7 @@
 	<binding>
                     <command>dialog-update</command>
                 </binding>
-	</radio>	
+	</checkbox>	
 	
         </group>
         <hrule/>
@@ -190,7 +190,7 @@
                 </binding>
                     </checkbox>
 		                        
-                    <radio>
+                    <checkbox>
                         <halign>left</halign>
                         <label>Enable left tie-down </label>
                         <property>/sim/model/c182s/securing/tiedownL-visible</property>
@@ -208,9 +208,9 @@
 			<binding>
 			<command>dialog-update</command>
 			</binding>
-                    </radio>
+                    </checkbox>
                     
-                    <radio>
+                    <checkbox>
                         <halign>left</halign>
                         <label>Enable right tie-down </label>
                         <property>/sim/model/c182s/securing/tiedownR-visible</property>
@@ -228,9 +228,9 @@
 			<binding>
 			<command>dialog-update</command>
 			</binding>
-                    </radio>
+                    </checkbox>
 
-                    <radio>
+                    <checkbox>
                         <halign>left</halign>
                         <label>Enable tail tie-down </label>
                         <property>/sim/model/c182s/securing/tiedownT-visible</property>
@@ -248,7 +248,7 @@
 			<binding>
 			<command>dialog-update</command>
 			</binding>
-                    </radio>
+                    </checkbox>
 
 			</group>
 


### PR DESCRIPTION
Closes #139 

Changing radios into checkboxes on securing and aircraft dialogs.

Note that the ground-equipement dialog is fine, since the radio there is used to select under which wing the stairs will be put (only one option can be selected)