### PR TITLE
Issue 164: wrong heading-indicator type

### DIFF
--- a/Nasal/c182s-electrical.nas
+++ b/Nasal/c182s-electrical.nas
@@ -585,9 +585,6 @@ avionics_bus_1 = func() {
     # Turn Coordinator Power
     setprop("/systems/electrical/outputs/turn-coordinator", bus_volts);
 
-    # Directional Gyro Power
-    setprop("/systems/electrical/outputs/DG", bus_volts);
-
     # Avionics Fan Power
     setprop("/systems/electrical/outputs/avionics-fan", bus_volts);
 

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -74,11 +74,11 @@ file, these values will be used (they are hardcoded).
     <number>0</number>
   </marker-beacon>
 
-  <heading-indicator-dg>
+  <heading-indicator>
     <name>heading-indicator</name>
     <number>0</number>
     <suction>/systems/vacuum/suction-inhg</suction>
-  </heading-indicator-dg>
+  </heading-indicator>
 
   <KT-70>
     <name>kt-70</name>


### PR DESCRIPTION
This PR fix Issue#164 and change the heading indicator to a vacuum driven one.