### PR TITLE
Added placard text to baggage door GUI

### DIFF
--- a/gui/dialogs/c182s-baggage-weight.xml
+++ b/gui/dialogs/c182s-baggage-weight.xml
@@ -34,6 +34,26 @@
         <layout>vbox</layout>
         <padding>6</padding>
         <empty><stretch>true</stretch></empty>
+        <text>
+            <label>120 POUNDS MAXIMUM BAGGAGE FORWARD OF BAGGAGE DOOR LATCH AND</label>
+        </text>
+        <text>
+            <label>80 POINDS MAXIMUM BAGGAGE AFT OF BAGGAGE DOOR LATCH</label>
+        </text>
+        <text>
+            <label>MAXIMUM 200 POUNDS COMBINED</label>
+        </text>
+        <text>
+            <label>FOR ADDITIONAL LOADING INSTRUCTIONS SEE WEIGHT AND BALANCE DATA</label>
+        </text>
+    </group>
+
+    <hrule/>
+    
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
+        <empty><stretch>true</stretch></empty>
         <group>
             <layout>hbox</layout>
             <text>


### PR DESCRIPTION
Added the POH placard text to the baggage GUI.
![image](https://user-images.githubusercontent.com/13608602/33769170-69002a46-dc29-11e7-8e3a-6bbc4ec7d052.png)

I think it would also be great to make the placard resolution in the texture good enough to be read in game from the walker.