### PR TITLE
Fix GMA dial rotation sound volume

### DIFF
--- a/c182s-sound.xml
+++ b/c182s-sound.xml
@@ -671,6 +671,9 @@
             </position>
             <reference-dist>0.2</reference-dist>
             <max-dist>5.0</max-dist>
+            <volume>
+                <factor>0.2</factor>
+            </volume>
         </switch>
         
         <switch>


### PR DESCRIPTION
The ICS dial was too loud; this PR adjusts the volume to comply with the other dials.