### PR TITLE
Made DME ident stop when DME power is switched off

### DIFF
--- a/Nasal/kn62a.nas
+++ b/Nasal/kn62a.nas
@@ -81,3 +81,13 @@ setlistener(nav1_state, func {
         }
     }
 });
+
+# Switch off ident volume when power button is off
+# (failing DME and loss-of-voltage is handled otherwise)
+var dme_pwrBtn = props.globals.getNode("/controls/switches/kn-62a");
+var updateIdentVolume = func {
+    setprop("/instrumentation/dme/volume", dme_pwrBtn.getValue());
+    setprop("/instrumentation/dme/power-btn", dme_pwrBtn.getValue()); #also adjust standard-property
+};
+
+setlistener(dme_pwrBtn, updateIdentVolume);


### PR DESCRIPTION
When the DME unit power-switch was switched to off, but GMA panel DME-Ident is on, the ident code was played.
I think the Ident should stop, when the DME is switched off, however.

This PR introduces a small nasal handler to the existing DME code that handles this.