### PR TITLE
Remove tiedowns when in the air

### DIFF
--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -365,14 +365,22 @@ WindowL = aircraft.door.new( "/sim/model/door-positions/WindowL", 2, 0 );
 # Adjust properties when in motion
 # - external electrical disconnect when groundspeed higher than 0.1ktn (replace later with distance less than 0.01...)
 # - remove external heat
+# - tear tiedowns when significantly off ground
 ad = func {
     GROUNDSPEED = getprop("/velocities/groundspeed-kt") or 0; 
+    AGL         = getprop("/position/altitude-agl-ft")  or 0;
 
     if (GROUNDSPEED > 0.1) {
         setprop("/controls/electric/external-power", "false");
-        setprop("/controls/electric/TEST", "true");
         setprop("/engines/engine/external-heat/enabled", "false");
     }
+    
+    if (AGL > 10) {
+        setprop("/sim/model/c182s/securing/tiedownT-visible", 0);
+        setprop("/sim/model/c182s/securing/tiedownL-visible", 0);
+        setprop("/sim/model/c182s/securing/tiedownR-visible", 0);
+    }
+    
     settimer(ad, 0.1);   
 }
 init = func {


### PR DESCRIPTION
Currently we can have strange effects when tiedowns are in place and the plane gets in the air.
This can happen for example, if the user presses STRG+U when tied down or (possibly, however already accounted for!) at in-air-starts.

When the Plane is more than 10ft in the air, the tiedowns are automaticly removed now.


(A short test just for fun showed that we need ~65 knots 90° to make the wind force dominate the tiedown force -> e.g. plane lifts off and tiedowns tear shortly after that)