### PR TITLE
Fix #223 (Fuel gauge always "on")

### DIFF
--- a/Models/Instruments/ManPressFuelFlow.xml
+++ b/Models/Instruments/ManPressFuelFlow.xml
@@ -47,7 +47,7 @@
    <animation>
         <type>rotate</type>
         <object-name>FuelFlowNeedle</object-name>
-        <property>/systems/fuel/indicated-manfold-fuel-flow-gph</property>
+        <property>/engines/engine/indicated-manfold-fuel-flow-gph</property>
  <interpolation>
       <entry><ind>0</ind><dep>0</dep></entry>
       <entry><ind>5</ind><dep> 5.27</dep></entry>

--- a/Models/Instruments/egt.xml
+++ b/Models/Instruments/egt.xml
@@ -25,7 +25,7 @@
     <animation>
   <type>rotate</type>
   <object-name>EGTNeedle</object-name>
-  <property>engines/engine/egt-degf</property>
+  <property>engines/engine/indicated-egt-degf</property>
   <interpolation>
    <entry><ind>  0.0</ind><dep>0 </dep></entry>     
    <entry><ind>1250</ind><dep> -11.0 </dep></entry>     
@@ -50,7 +50,7 @@
    <animation>
         <type>rotate</type>
         <object-name>CHTNeedle</object-name>
-  <property>engines/engine/cht-degf</property>
+  <property>engines/engine/indicated-cht-degf</property>
  <interpolation>
       <entry><ind>0</ind><dep> 0</dep></entry>
       <entry><ind>200</ind><dep>9.83</dep></entry>

--- a/Models/Instruments/fuelqty.xml
+++ b/Models/Instruments/fuelqty.xml
@@ -23,7 +23,7 @@
     <animation>
   <type>rotate</type>
         <object-name>FuelLeftNeedle</object-name>
-  <property>consumables/fuel/tank[0]/level-gal_us</property>
+  <property>consumables/fuel/tank[0]/indicated-level-gal_us</property>
   <interpolation>
    <entry><ind>  0.0</ind><dep>0 </dep></entry>     
    <entry><ind>5</ind><dep> -21.40 </dep></entry>     
@@ -47,7 +47,7 @@
    <animation>
         <type>rotate</type>
         <object-name>FuelRightNeedle</object-name>
-  <property>consumables/fuel/tank[1]/level-gal_us</property>
+  <property>consumables/fuel/tank[1]/indicated-level-gal_us</property>
   <interpolation>
    <entry><ind>  0.0</ind><dep>0 </dep></entry>     
    <entry><ind>5</ind><dep> 21.40 </dep></entry>     

--- a/Models/Instruments/oil.xml
+++ b/Models/Instruments/oil.xml
@@ -23,7 +23,7 @@
     <animation>
   <type>rotate</type>
   <object-name>OilTempNeedle</object-name>
-  <property>/engines/engine/oil-final-temperature-degf</property>
+  <property>/engines/engine/indicated-oil-final-temperature-degf</property>
   <interpolation>
    <entry><ind>  0.0</ind><dep>0 </dep></entry>     
    <entry><ind>75</ind><dep> -7.07 </dep></entry>     
@@ -48,7 +48,7 @@
    <animation>
         <type>rotate</type>
         <object-name>OilPressNeedle</object-name>
-  <property>engines/engine[0]/oil-pressure-psi-indicated</property>
+  <property>/engines/engine[0]/indicated-oil-pressure-psi</property>
  <interpolation>
       <entry><ind>0</ind><dep> 0</dep></entry>
       <entry><ind>20</ind><dep>19.63</dep></entry>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -252,7 +252,7 @@
             <property>/engines/engine/oil-pressure-psi</property>
         </input>
         <output>
-            <property>/engines/engine[0]/oil-pressure-psi-indicated</property>
+            <property>/engines/engine[0]/oil-pressure-psi-final</property>
         </output>
     </filter>
 

--- a/Systems/fuel.xml
+++ b/Systems/fuel.xml
@@ -47,7 +47,7 @@ Author: 09/2017  Benedikt Hallinger
     <property type="bool" value="0">/systems/fuel/engine-primed</property>
     <property type="bool" value="0">/systems/fuel/engine-flooded</property>
     
-    <property type="double" value="0">/systems/fuel/indicated-manfold-fuel-flow-gph</property>
+    <!-- now defined in instruments.xml filter: <property type="double" value="0">/systems/fuel/indicated-manfold-fuel-flow-gph</property>-->
 
     
     <channel name="fuel-system">

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -5,7 +5,7 @@
     <filter>
         <name>Tank 0 Indicated Level</name>
         <type>exponential</type>
-        <filter-time>3.0</filter-time>
+        <filter-time>2.0</filter-time>
         <input>
             <condition>
                 <greater-than>
@@ -26,7 +26,7 @@
     <filter>
         <name>Tank 1 Indicated Level</name>
         <type>exponential</type>
-        <filter-time>3.0</filter-time>
+        <filter-time>2.0</filter-time>
         <input>
             <condition>
                 <greater-than>
@@ -47,7 +47,7 @@
     <filter>
         <name>Engine Indicated Oil Temperature</name>
         <type>exponential</type>
-        <filter-time>3.0</filter-time>
+        <filter-time>1.0</filter-time>
         <input>
             <condition>
                 <greater-than>
@@ -68,7 +68,7 @@
     <filter>
         <name>Engine Indicated Oil Pressure</name>
         <type>exponential</type>
-        <filter-time>3.0</filter-time>
+        <filter-time>1.0</filter-time>
         <input>
             <condition>
                 <greater-than>
@@ -83,6 +83,69 @@
         </input>
         <output>
             <property>/engines/engine/indicated-oil-pressure-psi</property>
+        </output>
+    </filter>
+    
+    <filter>
+        <name>Engine Indicated EGT</name>
+        <type>exponential</type>
+        <filter-time>1.0</filter-time>
+        <input>
+            <condition>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+            </condition>
+            <property>/engines/engine/egt-degf</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/engines/engine/indicated-egt-degf</property>
+        </output>
+    </filter>
+    
+    <filter>
+        <name>Engine Indicated CHT</name>
+        <type>exponential</type>
+        <filter-time>1.0</filter-time>
+        <input>
+            <condition>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+            </condition>
+            <property>/engines/engine/cht-degf</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/engines/engine/indicated-cht-degf</property>
+        </output>
+    </filter>
+    
+    <filter>
+        <name>Engine Indicated Fuel Flow</name>
+        <type>exponential</type>
+        <filter-time>0.5</filter-time> <!-- be really responsive for priming readings -->
+        <input>
+            <condition>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+            </condition>
+            <property>/systems/fuel/indicated-manfold-fuel-flow-gph</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/engines/engine/indicated-manfold-fuel-flow-gph</property>
         </output>
     </filter>
     

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<PropertyList>
+    
+    <filter>
+        <name>Tank 0 Indicated Level</name>
+        <type>exponential</type>
+        <filter-time>3.0</filter-time>
+        <input>
+            <condition>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+            </condition>
+            <property>/consumables/fuel/tank[0]/level-gal_us</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/consumables/fuel/tank[0]/indicated-level-gal_us</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Tank 1 Indicated Level</name>
+        <type>exponential</type>
+        <filter-time>3.0</filter-time>
+        <input>
+            <condition>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+            </condition>
+            <property>/consumables/fuel/tank[1]/level-gal_us</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/consumables/fuel/tank[1]/indicated-level-gal_us</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Engine Indicated Oil Temperature</name>
+        <type>exponential</type>
+        <filter-time>3.0</filter-time>
+        <input>
+            <condition>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+            </condition>
+            <property>/engines/engine/oil-final-temperature-degf</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/engines/engine/indicated-oil-final-temperature-degf</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Engine Indicated Oil Pressure</name>
+        <type>exponential</type>
+        <filter-time>3.0</filter-time>
+        <input>
+            <condition>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+            </condition>
+            <property>/engines/engine/oil-pressure-psi-final</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/engines/engine/indicated-oil-pressure-psi</property>
+        </output>
+    </filter>
+    
+</PropertyList>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -52,6 +52,10 @@
     <property-rule n="104">
         <path>Aircraft/c182s/Systems/engine.xml</path>
     </property-rule>
+    <property-rule n="105">
+            <name>FiltersOnly</name>
+            <path>Systems/instruments.xml</path>
+    </property-rule>
     <electrical>        
       <!-- null electrical system path here so we can use a nasal based -->
       <!-- model defined later in the nasal section of this file. -->


### PR DESCRIPTION
Fixed the fuel quantity an oil-tem/press gauges to not show indication without power.

@HHS81 @gilbertohasnofb 
Before merge i have questions:
- Should the VAC EGT and CHT gauges behave the same? (i think so, as they surely are electrically driven too?)
- What about ManPress? I suppose (like in "guess") this is mechanically driven?