### PR TITLE
State additions

### DIFF
--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -539,13 +539,11 @@ var control_surface_check_rudder = func {
 ##########################################
 # REPAIR DAMAGE
 ##########################################
-var repair_damage = func {
+var repair_damage = func() {
     print("Repairing damage...");
-    reset_fuel_contamination();
     setprop("/engines/engine[0]/kill-engine", 0.0);
     setprop("/engines/engine[0]/crashed", 0.0);
     electrical.reset_battery_and_circuit_breakers();
-    setprop("/engines/engine[0]/oil-level", 8.0);
 };
 
 

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -28,6 +28,13 @@
   
   <checklists include="c182s-checklists.xml"/>
   
+  <!-- Overlays (called with "state" command line option) -->
+  <state include="states/auto-overlay.xml" n="0" />
+  <state include="states/parking-overlay.xml" n="1" />
+  <state include="states/idling-overlay.xml" n="2" />
+  <state include="states/cruising-overlay.xml" n="3" />
+  <state include="states/approach-overlay.xml" n="4" />
+  
   <systems>
     <autopilot>
         <!-- <path>Aircraft/c182s/generic-autopilot.xml</path>-->

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -63,11 +63,8 @@
     </electrical>
   </systems>
   
-  <start-state_saved type="bool">false</start-state_saved>
-  <start-state_auto type="bool">true</start-state_auto>
-  <start-state_CnD type="bool">false</start-state_CnD>
-  <start-state_RfT type="bool">false</start-state_RfT>
-  <start-state_Crs type="bool">false</start-state_Crs>
+  <!-- Aircraft states -->
+  <start-state type="string">auto</start-state>
   <start-state-internal>
       <oil-temp-override type="bool">false</oil-temp-override>
   </start-state-internal>
@@ -537,11 +534,7 @@
         
         <!-- Save these properties between sessions -->
         <aircraft-data>
-            <path>/sim/start-state_auto</path>
-            <path>/sim/start-state_saved</path>
-            <path>/sim/start-state_CnD</path>
-            <path>/sim/start-state_RfT</path>
-            <path>/sim/start-state_Crs</path>
+            <path>/sim/start-state</path>
             
             <path>/sim/time/hobbs/engine</path>
             <path>/engines/engine/complex-engine-procedures</path>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -51,171 +51,101 @@
         <radio>
             <halign>left</halign>
             <label>Automatic</label>
-            <property>/sim/start-state_auto</property>
+            <property>/sim/start-state-internal/gui-radio-auto</property>
             <live>true</live>
             <binding>
                 <command>dialog-apply</command>
             </binding>
             <binding>
                 <command>property-assign</command>
-                <property>/sim/start-state_saved</property>
-                <value>0</value>
+                <property>/sim/start-state</property>
+                <value>auto</value>
             </binding>
             <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_CnD</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_RfT</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_Crs</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_auto</property>
-                <value>1</value>
+                <command>nasal</command>
+                <script>
+                    c182s.updateStateSettingGUI();
+                </script>
             </binding>
         </radio>
         <radio>
             <halign>left</halign>
             <label>Saved state</label>
-            <property>/sim/start-state_saved</property>
+            <property>/sim/start-state-internal/gui-radio-saved</property>
             <live>true</live>
             <binding>
                 <command>dialog-apply</command>
             </binding>
             <binding>
                 <command>property-assign</command>
-                <property>/sim/start-state_saved</property>
-                <value>1</value>
+                <property>/sim/start-state</property>
+                <value>saved</value>
             </binding>
             <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_CnD</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_RfT</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_Crs</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_auto</property>
-                <value>0</value>
+                <command>nasal</command>
+                <script>
+                    c182s.updateStateSettingGUI();
+                </script>
             </binding>
         </radio>
         <radio>
             <halign>left</halign>
             <label>Cold and Dark</label>
-            <property>/sim/start-state_CnD</property>
+            <property>/sim/start-state-internal/gui-radio-cold-and-dark</property>
             <live>true</live>
             <binding>
                 <command>dialog-apply</command>
             </binding>
             <binding>
                 <command>property-assign</command>
-                <property>/sim/start-state_saved</property>
-                <value>0</value>
+                <property>/sim/start-state</property>
+                <value>cold-and-dark</value>
             </binding>
             <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_CnD</property>
-                <value>1</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_RfT</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_Crs</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_auto</property>
-                <value>0</value>
+                <command>nasal</command>
+                <script>
+                    c182s.updateStateSettingGUI();
+                </script>
             </binding>
         </radio>
         <radio>
             <halign>left</halign>
             <label>Ready for Takeoff</label>
-            <property>/sim/start-state_RfT</property>
+            <property>/sim/start-state-internal/gui-radio-ready-for-takeoff</property>
             <live>true</live>
             <binding>
                 <command>dialog-apply</command>
             </binding>
             <binding>
                 <command>property-assign</command>
-                <property>/sim/start-state_saved</property>
-                <value>0</value>
+                <property>/sim/start-state</property>
+                <value>ready-for-takeoff</value>
             </binding>
             <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_CnD</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_RfT</property>
-                <value>1</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_Crs</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_auto</property>
-                <value>0</value>
+                <command>nasal</command>
+                <script>
+                    c182s.updateStateSettingGUI();
+                </script>
             </binding>
         </radio>
         <radio>
             <halign>left</halign>
             <label>Cruising</label>
-            <property>/sim/start-state_Crs</property>
+            <property>/sim/start-state-internal/gui-radio-cruising</property>
             <live>true</live>
             <binding>
                 <command>dialog-apply</command>
             </binding>
             <binding>
                 <command>property-assign</command>
-                <property>/sim/start-state_saved</property>
-                <value>0</value>
+                <property>/sim/start-state</property>
+                <value>cruising</value>
             </binding>
             <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_CnD</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_RfT</property>
-                <value>0</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_Crs</property>
-                <value>1</value>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property>/sim/start-state_auto</property>
-                <value>0</value>
+                <command>nasal</command>
+                <script>
+                    c182s.updateStateSettingGUI();
+                </script>
             </binding>
         </radio>
         
@@ -230,7 +160,7 @@
                         <property>/sim/freeze/replay-state</property>
                     </not>
                     <not>
-                        <property>/sim/start-state_saved</property>
+                        <property>/sim/start-state-internal/gui-radio-saved</property>
                     </not>
                 </and>
             </enable>

--- a/states/approach-overlay.xml
+++ b/states/approach-overlay.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<PropertyList>
+
+  <name type="string" n="4">approach</name>
+
+  <description>
+    The plane will be in "approach" state with engines running.
+    Initial Airspeed is set to 80 knots.
+    You should also set an --altitude=... setting to start in-air
+    and an offset position to a runway to practice approaches or use the launcher to set this up.
+
+    Start this state with --state=approach.
+  </description>
+
+  <overlay>
+    <environment>
+      <overlay type="bool">true</overlay>
+    </environment>
+
+    <sim>
+        <!-- actual init is done via nasal "c182s-states.nas";
+             this value indicates the preset to it. -->
+        <init-state type="string">cruising</init-state>
+        
+      <presets>
+        <airspeed-kt type="double">80</airspeed-kt>
+      </presets>
+    </sim>
+
+  </overlay>
+</PropertyList>

--- a/states/auto-overlay.xml
+++ b/states/auto-overlay.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<PropertyList>
+
+  <name type="string" n="0">auto</name>
+
+  <description>
+    The plane state is automatically detected based on selected position:
+    - in-air: cruise
+    - airport parking position: parking (cold and dark)
+    - other: ready for take-off
+
+    Start this state with --state=auto
+  </description>
+
+  <overlay>
+    <environment>
+      <overlay type="bool">true</overlay>
+    </environment>
+
+    <sim>
+        <!-- actual init is done via nasal "c182s-states.nas";
+             this value indicates the preset to it. -->
+        <init-state type="string">auto</init-state>
+        <!--
+      <presets>
+        <airspeed-kt type="double">180</airspeed-kt>
+        </presets>-->
+    </sim>
+
+  </overlay>
+</PropertyList>

--- a/states/cruising-overlay.xml
+++ b/states/cruising-overlay.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<PropertyList>
+
+  <name type="string" n="3">cruise</name>
+
+  <description>
+    The plane will be in "crusing" state with engines running.
+    Initial Airspeed is set to 100 knots unless specified otherwise (eg. --vc=120)
+    You should also set an --altitude=... setting to start in-air.
+
+    Start this state with --state=cruising.
+  </description>
+
+  <overlay>
+    <environment>
+      <overlay type="bool">true</overlay>
+    </environment>
+
+    <sim>
+        <!-- actual init is done via nasal "c182s-states.nas";
+             this value indicates the preset to it. -->
+        <init-state type="string">cruising</init-state>
+        <!--
+      <presets>
+        <airspeed-kt type="double">180</airspeed-kt>
+        </presets>-->
+    </sim>
+
+  </overlay>
+</PropertyList>

--- a/states/idling-overlay.xml
+++ b/states/idling-overlay.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<PropertyList>
+
+  <name type="string" n="2">take-off</name>
+
+  <description>
+    The plane will be in "ready-for-takeoff" state.
+    preflight checklist is complete and the engine is ready for takeoff.
+
+    Start this state with --state=ready-for-takeoff
+  </description>
+
+  <overlay>
+    <environment>
+      <overlay type="bool">true</overlay>
+    </environment>
+
+    <sim>
+        <!-- actual init is done via nasal "c182s-states.nas";
+             this value indicates the preset to it. -->
+        <init-state type="string">ready-for-takeoff</init-state>
+        <!--
+      <presets>
+        <airspeed-kt type="double">180</airspeed-kt>
+        </presets>-->
+    </sim>
+
+  </overlay>
+</PropertyList>

--- a/states/parking-overlay.xml
+++ b/states/parking-overlay.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<PropertyList>
+
+  <name type="string" n="1">parking</name>
+
+  <description>
+    The plane will be in "cold-and-dark" state, that is parked and secured, with all
+    equipment switched off. Preflight inspection has not be done yet.
+
+    Start this state with --state=cold-and-dark
+  </description>
+
+  <overlay>
+    <environment>
+      <overlay type="bool">true</overlay>
+    </environment>
+
+    <sim>
+        <!-- actual init is done via nasal "c182s-states.nas";
+             this value indicates the preset to it. -->
+        <init-state type="string">cold-and-dark</init-state>
+        <!--
+      <presets>
+        <airspeed-kt type="double">180</airspeed-kt>
+        </presets>-->
+    </sim>
+
+  </overlay>
+</PropertyList>


### PR DESCRIPTION
- [x] Rewrite of state-init system:
  Now it is possible to init state from command line: add for example "`--prop:/sim/start-state=cruising`"
  This is very useful in combination with `--vc=120` and gui-launcher setting "on final approach..." to practise landings

- [x] Additions to state code
    - Refactored state-code a little
    - state "ColdAndDark" is now always before preflight (secured and with fuel contamination and without oil/fuel checked

- [x] Experiment with state-overlay, so giving "`--state=xxx`"-Option is supported too