### PR TITLE
GMA-340: enhance marker handling

### DIFF
--- a/Models/Instruments/Avionics/gma340.xml
+++ b/Models/Instruments/Avionics/gma340.xml
@@ -401,13 +401,20 @@
     <type>pick</type>
     <object-name>gma340.pick.mkr</object-name>
     <visible>true</visible>
-    <!-- todo: according to manual: when marker is active, it can be muted but remains selected -->
     <action>
       <button>0</button>
       <repeatable>false</repeatable>
       <binding>
         <command>property-toggle</command>
-        <property>/instrumentation/marker-beacon/audio-btn</property>
+        <property>/instrumentation/audio-panel/mkr</property>
+        <condition>
+            <property>/instrumentation/audio-panel/serviceable</property>
+            <property>/instrumentation/audio-panel/power-btn</property>
+        </condition>
+      </binding>
+      <binding>
+        <command>nasal</command>
+        <script>c182s.gma340_toggleMarkerMute()</script>
         <condition>
             <property>/instrumentation/audio-panel/serviceable</property>
             <property>/instrumentation/audio-panel/power-btn</property>
@@ -427,7 +434,7 @@
       <property>/instrumentation/audio-panel/power-btn</property>
       <property>/systems/electrical/outputs/audio-panel</property>
       <or>
-        <property>/instrumentation/marker-beacon/audio-btn</property>
+        <property>/instrumentation/audio-panel/mkr</property>
         <property>/instrumentation/audio-panel/test</property>
       </or>
     </condition>

--- a/Models/Instruments/Avionics/gma340.xml
+++ b/Models/Instruments/Avionics/gma340.xml
@@ -91,9 +91,6 @@
     <type>material</type>
     <object-name>gma340.Marker.O</object-name>
     <condition>
-      <property>/instrumentation/audio-panel/serviceable</property>
-      <property>/instrumentation/audio-panel/power-btn</property>
-      <property>/systems/electrical/outputs/audio-panel</property>
       <not><property>/instrumentation/marker-beacon/outer</property></not>
       <not><property>/instrumentation/audio-panel/test</property></not>
     </condition>
@@ -147,9 +144,6 @@
     <type>material</type>
     <object-name>gma340.Marker.M</object-name>
     <condition>
-      <property>/instrumentation/audio-panel/serviceable</property>
-      <property>/instrumentation/audio-panel/power-btn</property>
-      <property>/systems/electrical/outputs/audio-panel</property>
       <not><property>/instrumentation/marker-beacon/middle</property></not>
       <not><property>/instrumentation/audio-panel/test</property></not>
     </condition>
@@ -203,9 +197,6 @@
     <type>material</type>
     <object-name>gma340.Marker.I</object-name>
     <condition>
-      <property>/instrumentation/audio-panel/serviceable</property>
-      <property>/instrumentation/audio-panel/power-btn</property>
-      <property>/systems/electrical/outputs/audio-panel</property>
       <not><property>/instrumentation/marker-beacon/inner</property></not>
       <not><property>/instrumentation/audio-panel/test</property></not>
     </condition>

--- a/Models/Instruments/Avionics/gma340properties.xml
+++ b/Models/Instruments/Avionics/gma340properties.xml
@@ -19,6 +19,7 @@
   <serviceable   archive="n" type="bool">true</serviceable>
   <power-btn     archive="y" type="bool">true</power-btn>
   <dme           archive="y" type="bool">true</dme>
+  <mkr           archive="y" type="bool">true</mkr>
   <hi            archive="y" type="bool">true</hi>
   <lo            archive="y" type="bool">false</lo>
   <com     n="0" archive="y" type="bool">true</com>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -595,6 +595,7 @@
             <path>/instrumentation/audio-panel/lo</path>
             <path>/instrumentation/audio-panel/volume-ics-pilot</path>
             <path>/instrumentation/marker-beacon/audio-btn</path>
+            <path>/instrumentation/marker-beacon/volume-default</path> <!-- hard wired in GMA340, but can be changed (in-sim just adjust the property) -->
             <path>/surface-positions/flap-pos-norm</path>
             <path>/instrumentation/nav[0]/radials/selected-deg</path>
             <path>/instrumentation/nav[0]/frequencies/selected-mhz</path>


### PR DESCRIPTION
GMA340: Enhanced marker handling
 - marker is now silent, when audio panel is inoperable or shut off
 - marker can be temporarily muted now like described in manual (press "mkr-mute" once when marker-beacon is sounding)
 - Fix for lighting of beacon-indicators when GMA is powered off
