### PR TITLE
Fix #176 (trim wheels are now lit)

### DIFF
--- a/Models/interior-model.xml
+++ b/Models/interior-model.xml
@@ -76,6 +76,10 @@
     <object-name>Breaker.ADF</object-name>
     <object-name>Breaker.AutoPilot</object-name>
     <object-name>CowlFlapsLever</object-name>
+    <object-name>TrimElevator</object-name>
+    <object-name>ElevatorTrimPos</object-name>
+    <object-name>RudderTrim</object-name>
+    <object-name>RudderTrimPos</object-name>
    </effect>
 
    <effect>
@@ -84,6 +88,10 @@
       <object-name>key</object-name>
       <object-name>start</object-name>
       <object-name>starter</object-name>
+      <object-name>TrimElevator</object-name>
+      <object-name>ElevatorTrimPos</object-name>
+      <object-name>RudderTrim</object-name>
+      <object-name>RudderTrimPos</object-name>
    </effect>
    
 <effect>


### PR DESCRIPTION
Add light effects to trim wheels (cabin lights and flashlight)

I know its not the best we can have, but for now it looks OK and enhances usability at night:

With:
![image](https://user-images.githubusercontent.com/13608602/36310735-4a3fb360-1329-11e8-9da4-8c01b30c1b12.png)

Without:
![image](https://user-images.githubusercontent.com/13608602/36310920-cf4f2c2a-1329-11e8-9790-caa930ac1528.png)


With and with flashlight:
![image](https://user-images.githubusercontent.com/13608602/36310852-953fc1de-1329-11e8-8e7a-5adfcf7fdbb5.png)


Without and flashlight:
![image](https://user-images.githubusercontent.com/13608602/36310825-802a8c7a-1329-11e8-9781-e54529fe2422.png)
