### PR TITLE
Fix #271 (add "saved" state overlay so it gets selectable in new launcher)

### DIFF
--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -29,11 +29,12 @@
   <checklists include="c182s-checklists.xml"/>
   
   <!-- Overlays (called with "state" command line option) -->
-  <state include="states/auto-overlay.xml" n="0" />
-  <state include="states/parking-overlay.xml" n="1" />
-  <state include="states/idling-overlay.xml" n="2" />
-  <state include="states/cruising-overlay.xml" n="3" />
-  <state include="states/approach-overlay.xml" n="4" />
+  <state include="states/auto-overlay.xml"     n="0" />
+  <state include="states/saved-overlay.xml"    n="1" />
+  <state include="states/parking-overlay.xml"  n="2" />
+  <state include="states/idling-overlay.xml"   n="3" />
+  <state include="states/cruising-overlay.xml" n="4" />
+  <state include="states/approach-overlay.xml" n="5" />
   
   <systems>
  <path>Aircraft/c182s/Systems/systems.xml</path>

--- a/states/saved-overlay.xml
+++ b/states/saved-overlay.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<PropertyList>
+
+  <name type="string">Saved</name>
+
+  <description>
+    The plane will be in the state you left it the last time.
+
+    Start this state with --state=saved
+  </description>
+
+  <overlay>
+    <environment>
+      <overlay type="bool">true</overlay>
+    </environment>
+
+    <sim>
+        <!-- actual init is done via nasal "c182s-states.nas";
+             this value indicates the preset to it. -->
+        <init-state type="string">saved</init-state>
+
+    </sim>
+
+  </overlay>
+</PropertyList>


### PR DESCRIPTION
Like the title says:
![image](https://user-images.githubusercontent.com/13608602/41738663-fcc9419c-7592-11e8-90ab-5a36796fc329.png)
