### PR TITLE
Made state overlays comply to new launcher

### DIFF
--- a/states/cruising-overlay.xml
+++ b/states/cruising-overlay.xml
@@ -9,7 +9,7 @@
     Initial Airspeed is set to 100 knots unless specified otherwise (eg. --vc=120)
     You should also set an --altitude=... setting to start in-air.
 
-    Start this state with --state=cruising.
+    Start this state with --state=cruise.
   </description>
 
   <overlay>

--- a/states/idling-overlay.xml
+++ b/states/idling-overlay.xml
@@ -8,7 +8,7 @@
     The plane will be in "ready-for-takeoff" state.
     preflight checklist is complete and the engine is ready for takeoff.
 
-    Start this state with --state=ready-for-takeoff
+    Start this state with --state=take-off
   </description>
 
   <overlay>

--- a/states/parking-overlay.xml
+++ b/states/parking-overlay.xml
@@ -8,7 +8,7 @@
     The plane will be in "cold-and-dark" state, that is parked and secured, with all
     equipment switched off. Preflight inspection has not be done yet.
 
-    Start this state with --state=cold-and-dark
+    Start this state with --state=parking
   </description>
 
   <overlay>

--- a/states/saved-overlay.xml
+++ b/states/saved-overlay.xml
@@ -2,7 +2,7 @@
 
 <PropertyList>
 
-  <name type="string">Saved</name>
+  <name type="string">saved</name>
 
   <description>
     The plane will be in the state you left it the last time.


### PR DESCRIPTION
I corrected the descriptions text to comply to the launcher items.
No big deal, just documentatory.

the saved state was "broken" when called from command line (it was accidentally called "Saved" instead of the lowercase variant)