### PR TITLE
Correct door drag numbers and force-close doors in flight (remainder from pr #278)

### DIFF
--- a/Models/c182s.xml
+++ b/Models/c182s.xml
@@ -707,7 +707,7 @@
    <object-name>WindowFrame.L</object-name>
 <object-name>Window.L</object-name>
 <object-name>Window.L.001</object-name>
-   <property>sim/model/door-positions/DoorL/position-norm</property>
+   <property>sim/model/door-positions/DoorL/position-norm-effective</property>
    <interpolation>
      <entry>
        <ind>0.0</ind>
@@ -755,7 +755,7 @@
    <object-name>WindowFrame.R</object-name>
 <object-name>Window.R</object-name>
 <object-name>Window.R.001</object-name>
-   <property>sim/model/door-positions/DoorR/position-norm</property>
+   <property>sim/model/door-positions/DoorR/position-norm-effective</property>
    <interpolation>
      <entry>
        <ind>0.0</ind>
@@ -1096,7 +1096,7 @@
  <animation>
    <type>rotate</type>
    <object-name>BaggageDoor</object-name>
-   <property>sim/model/door-positions/BaggageDoor/position-norm</property>
+   <property>sim/model/door-positions/BaggageDoor/position-norm-effective</property>
    <interpolation>
      <entry>
        <ind>0.0</ind>

--- a/Models/interior-model.xml
+++ b/Models/interior-model.xml
@@ -155,7 +155,7 @@
 <object-name>doorhandleint_left</object-name>
 <object-name>FrameLock1.L</object-name>
 <object-name>FrameLock2.L</object-name>
-   <property>sim/model/door-positions/DoorL/position-norm</property>
+   <property>sim/model/door-positions/DoorL/position-norm-effective</property>
    <interpolation>
      <entry>
        <ind>0.0</ind>
@@ -190,7 +190,7 @@
 <object-name>doorhandleint_right</object-name>
 <object-name>FrameLock1.R</object-name>
 <object-name>FrameLock2.R</object-name>
-   <property>sim/model/door-positions/DoorR/position-norm</property>
+   <property>sim/model/door-positions/DoorR/position-norm-effective</property>
    <interpolation>
      <entry>
        <ind>0.0</ind>
@@ -264,23 +264,51 @@
     <animation>
         <type>rotate</type>
         <object-name>doorhandleint_right</object-name>
-   <property>sim/model/door-positions/DoorR/position-norm</property>
+        <property>sim/model/door-positions/DoorR/position-norm-effective</property>
+        <condition>
+            <equals>
+                <property>/sim/model/door-positions/DoorR/opened</property>
+                <value>0.0</value>
+            </equals>
+        </condition>
+        <condition>
+            <equals>
+                <property>/sim/model/door-positions/leftDoor/opened</property>
+                <value>0.0</value>
+            </equals>
+        </condition>
         <interpolation>
             <entry>
                 <ind>0.0</ind>
                 <dep>0.0</dep>
             </entry>
             <entry>
+                <ind>0.18</ind>
+                <dep>70.0</dep>
+            </entry>
+            <entry>
+                <ind>0.26</ind>
+                <dep>70.0</dep>
+            </entry>
+            <entry>
+                <ind>0.35</ind>
+                <dep>110.0</dep>
+            </entry>
+            <entry>
+                <ind>0.43</ind>
+                <dep>110.0</dep>
+            </entry>
+            <entry>
                 <ind>0.5</ind>
-                <dep>50.0</dep>
+                <dep>0.0</dep>
             </entry>
             <entry>
                 <ind>1</ind>
-                <dep>50.0</dep>
+                <dep>0.0</dep>
             </entry>
         </interpolation>
 		<center>
-			<x-m>0.969679</x-m>
+			<x-m>0.903840</x-m>
 			<y-m>0.569469</y-m>
 			<z-m>0.143912</z-m>
 		</center>
@@ -400,23 +428,45 @@
     <animation>
         <type>rotate</type>
         <object-name>doorhandleint_left</object-name>
-   <property>sim/model/door-positions/DoorL/position-norm</property>
+        <property>sim/model/door-positions/DoorL/position-norm-effective</property>
+        <condition>
+            <equals>
+                <property>/sim/model/door-positions/DoorL/opened</property>
+                <value>0.0</value>
+            </equals>
+        </condition>
         <interpolation>
             <entry>
                 <ind>0.0</ind>
                 <dep>0.0</dep>
             </entry>
             <entry>
+                <ind>0.18</ind>
+                <dep>70.0</dep>
+            </entry>
+            <entry>
+                <ind>0.26</ind>
+                <dep>70.0</dep>
+            </entry>
+            <entry>
+                <ind>0.35</ind>
+                <dep>110.0</dep>
+            </entry>
+            <entry>
+                <ind>0.43</ind>
+                <dep>110.0</dep>
+            </entry>
+            <entry>
                 <ind>0.5</ind>
-                <dep>50.0</dep>
+                <dep>0.0</dep>
             </entry>
             <entry>
                 <ind>1</ind>
-                <dep>50.0</dep>
+                <dep>0.0</dep>
             </entry>
         </interpolation>
 		<center>
-			<x-m>0.969679</x-m>
+			<x-m>0.903840</x-m>
 			<y-m>-0.569469</y-m>
 			<z-m>0.143912</z-m>
 		</center>
@@ -513,7 +563,7 @@
  <animation>
    <type>rotate</type>
 <object-name>BaggageIntDoor</object-name>
-   <property>sim/model/door-positions/BaggageDoor/position-norm</property>
+   <property>sim/model/door-positions/BaggageDoor/position-norm-effective</property>
    <interpolation>
      <entry>
        <ind>0.0</ind>

--- a/Nasal/c182s-states.nas
+++ b/Nasal/c182s-states.nas
@@ -226,6 +226,14 @@ var checklist_beforeEngineStart = func() {
     # Set heading offset
     var magnetic_variation = getprop("/environment/magnetic-variation-deg");
     setprop("/instrumentation/heading-indicator/offset-deg", -magnetic_variation);
+    
+    # close doors
+    DoorL.close();
+    DoorR.close();
+    BaggageDoor.close();
+    # may remain open: WindowL.close();
+    # may remain open: WindowR.close();
+
 }
 
 

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -371,11 +371,7 @@ var slamShutDoors = func() {
             doorEntity.swingtime = 0.5;
             doorEntity.close();
             doorEntity.swingtime = oriSwingTime;
-            print("DBG: check door: SHUT CLOSE: " ~ doorEntity.node.getPath() ~ " (airspeed=" ~ airspeed ~ "; groundspeed=" ~ groundspeed ~ ")");
-        } else {
-            print("DBG: check door: unchanged:  " ~ doorEntity.node.getPath() ~ " (airspeed=" ~ airspeed ~ "; groundspeed=" ~ groundspeed ~ ")");
-        }
-        
+        }        
     }
 };
 slamShutDoors_loop = maketimer(2, slamShutDoors);

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -360,6 +360,28 @@ BaggageDoor = aircraft.door.new( "/sim/model/door-positions/BaggageDoor", 2, 0 )
 WindowR = aircraft.door.new( "/sim/model/door-positions/WindowR", 2, 0 );
 WindowL = aircraft.door.new( "/sim/model/door-positions/WindowL", 2, 0 );
 
+# Slam shut doors due to airspeed
+var slamShutDoors = func() {
+    airspeed    = getprop("/velocities/airspeed-kt") or 0;
+    groundspeed = getprop("/velocities/groundspeed-kt") or 0;
+    doorOpenChecks = [DoorL, DoorR, BaggageDoor];
+    foreach(doorEntity; doorOpenChecks) {
+        if (abs(airspeed) > 35 and groundspeed > 1 and doorEntity.getpos() > 0) {
+            var oriSwingTime = doorEntity.swingtime;
+            doorEntity.swingtime = 0.5;
+            doorEntity.close();
+            doorEntity.swingtime = oriSwingTime;
+            print("DBG: check door: SHUT CLOSE: " ~ doorEntity.node.getPath() ~ " (airspeed=" ~ airspeed ~ "; groundspeed=" ~ groundspeed ~ ")");
+        } else {
+            print("DBG: check door: unchanged:  " ~ doorEntity.node.getPath() ~ " (airspeed=" ~ airspeed ~ "; groundspeed=" ~ groundspeed ~ ")");
+        }
+        
+    }
+};
+slamShutDoors_loop = maketimer(2, slamShutDoors);
+slamShutDoors_loop.start();
+
+
 #####################
 # Adjust properties when in motion
 # - external electrical disconnect when groundspeed higher than 0.1ktn (replace later with distance less than 0.01...)

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -360,23 +360,6 @@ BaggageDoor = aircraft.door.new( "/sim/model/door-positions/BaggageDoor", 2, 0 )
 WindowR = aircraft.door.new( "/sim/model/door-positions/WindowR", 2, 0 );
 WindowL = aircraft.door.new( "/sim/model/door-positions/WindowL", 2, 0 );
 
-# Slam shut doors due to airspeed
-var slamShutDoors = func() {
-    airspeed    = getprop("/velocities/airspeed-kt") or 0;
-    groundspeed = getprop("/velocities/groundspeed-kt") or 0;
-    doorOpenChecks = [DoorL, DoorR, BaggageDoor];
-    foreach(doorEntity; doorOpenChecks) {
-        if (abs(airspeed) > 35 and groundspeed > 1 and doorEntity.getpos() > 0) {
-            var oriSwingTime = doorEntity.swingtime;
-            doorEntity.swingtime = 0.5;
-            doorEntity.close();
-            doorEntity.swingtime = oriSwingTime;
-        }        
-    }
-};
-slamShutDoors_loop = maketimer(2, slamShutDoors);
-slamShutDoors_loop.start();
-
 
 #####################
 # Adjust properties when in motion

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -354,11 +354,23 @@ settimer(init_common,0);
 	
 
 # doors ============================================================
-DoorL = aircraft.door.new( "/sim/model/door-positions/DoorL", 2, 0 );
-DoorR = aircraft.door.new( "/sim/model/door-positions/DoorR", 2, 0 );
+DoorL       = aircraft.door.new( "/sim/model/door-positions/DoorL", 2, 0 );
+DoorR       = aircraft.door.new( "/sim/model/door-positions/DoorR", 2, 0 );
 BaggageDoor = aircraft.door.new( "/sim/model/door-positions/BaggageDoor", 2, 0 );
-WindowR = aircraft.door.new( "/sim/model/door-positions/WindowR", 2, 0 );
-WindowL = aircraft.door.new( "/sim/model/door-positions/WindowL", 2, 0 );
+WindowR     = aircraft.door.new( "/sim/model/door-positions/WindowR", 2, 0 );
+WindowL     = aircraft.door.new( "/sim/model/door-positions/WindowL", 2, 0 );
+
+# restore saved door state
+DoorL_saved       = getprop("/sim/model/door-positions/DoorL/position-norm") or 0;
+DoorR_saved       = getprop("/sim/model/door-positions/DoorR/position-norm") or 0;
+BaggageDoor_saved = getprop("/sim/model/door-positions/BaggageDoor/position-norm") or 0;
+WindowL_saved     = getprop("/sim/model/door-positions/WindowL/position-norm") or 0;
+WindowR_saved     = getprop("/sim/model/door-positions/WindowR/position-norm") or 0;
+DoorL.setpos(DoorL_saved);
+DoorR.setpos(DoorR_saved);
+BaggageDoor.setpos(BaggageDoor_saved);
+WindowL.setpos(WindowL_saved);
+WindowR.setpos(WindowR_saved);
 
 
 #####################

--- a/Systems/ground-effects.xml
+++ b/Systems/ground-effects.xml
@@ -189,5 +189,202 @@ Under the GPL. Used by shadows under ALS -->
             <property>/sim/model/c182s/securing/tiedownT-addable</property>
         </output>
     </logic>
+    
+    <!-- ================================================================== -->
+    <!-- Checking if doors are opened or closed in order to skip or not     -->
+    <!-- the handle animation                                               -->
+    <!-- ================================================================== -->
+
+    <filter>
+        <name>Right door opened</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <or>
+                    <equals>
+                        <property>/sim/model/door-positions/DoorR/position-norm</property>
+                        <value>1.0</value>
+                    </equals>
+                    <equals>
+                        <property>/sim/model/door-positions/DoorR/position-norm</property>
+                        <value>0.0</value>
+                    </equals>
+                </or>
+            </condition>
+        </enable>
+        <input>
+            <condition>
+                <equals>
+                    <property>/sim/model/door-positions/DoorR/position-norm</property>
+                    <value>1.0</value>
+                </equals>
+            </condition>
+            <value>1.0</value>
+        </input>
+        <input>
+            <condition>
+                <equals>
+                    <property>/sim/model/door-positions/DoorR/position-norm</property>
+                    <value>0.0</value>
+                </equals>
+            </condition>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/sim/model/door-positions/DoorR/opened</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Left door opened</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <or>
+                    <equals>
+                        <property>/sim/model/door-positions/DoorL/position-norm</property>
+                        <value>1.0</value>
+                    </equals>
+                    <equals>
+                        <property>/sim/model/door-positions/DoorL/position-norm</property>
+                        <value>0.0</value>
+                    </equals>
+                </or>
+            </condition>
+        </enable>
+        <input>
+            <condition>
+                <equals>
+                    <property>/sim/model/door-positions/DoorL/position-norm</property>
+                    <value>1.0</value>
+                </equals>
+            </condition>
+            <value>1.0</value>
+        </input>
+        <input>
+            <condition>
+                <equals>
+                    <property>/sim/model/door-positions/DoorL/position-norm</property>
+                    <value>0.0</value>
+                </equals>
+            </condition>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/sim/model/door-positions/DoorL/opened</property>
+        </output>
+    </filter>
+    
+    <!-- ================================================================== -->
+    <!-- Max range for doors and baggage doors  -->
+    <!-- ================================================================== -->
+
+    <filter>
+        <name>Effective range for right door</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <product>
+                    <property>/sim/model/door-positions/DoorR/position-norm</property>
+                    <max>
+                        <min>
+                            <difference>
+                                <value>1.0</value>
+                                <product>
+                                    <sum>
+                                        <property>/velocities/airspeed-kt</property>
+                                        <sin>
+                                            <product>
+                                                <value>1.07</value>
+                                                <property>/velocities/airspeed-kt</property>
+                                            </product>
+                                        </sin>
+                                    </sum>
+                                    <value>0.01</value>
+                                </product>
+                            </difference>
+                            <value>1.0</value>
+                        </min>
+                        <value>0.51</value>
+                    </max>
+                </product>
+            </expression>
+        </input>
+        <output>
+            <property>/sim/model/door-positions/DoorR/position-norm-effective</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Effective range for left door</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <product>
+                    <property>/sim/model/door-positions/DoorL/position-norm</property>
+                    <max>
+                        <min>
+                            <difference>
+                                <value>1.0</value>
+                                <product>
+                                    <sum>
+                                        <property>/velocities/airspeed-kt</property>
+                                        <sin>
+                                            <product>
+                                                <value>1.38</value>
+                                                <property>/velocities/airspeed-kt</property>
+                                            </product>
+                                        </sin>
+                                    </sum>
+                                    <value>0.01</value>
+                                </product>
+                            </difference>
+                            <value>1.0</value>
+                        </min>
+                        <value>0.51</value>
+                    </max>
+                </product>
+            </expression>
+        </input>
+        <output>
+            <property>/sim/model/door-positions/DoorL/position-norm-effective</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Effective range for baggage door</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <product>
+                    <property>/sim/model/door-positions/BaggageDoor/position-norm</property>
+                    <max>
+                        <min>
+                            <difference>
+                                <value>1.0</value>
+                                <product>
+                                    <sum>
+                                        <property>/velocities/airspeed-kt</property>
+                                        <sin>
+                                            <product>
+                                                <value>0.73</value>
+                                                <property>/velocities/airspeed-kt</property>
+                                            </product>
+                                        </sin>
+                                    </sum>
+                                    <value>0.02</value>
+                                </product>
+                            </difference>
+                            <value>1.0</value>
+                        </min>
+                        <value>0.02</value>
+                    </max>
+                </product>
+            </expression>
+        </input>
+        <output>
+            <property>/sim/model/door-positions/BaggageDoor/position-norm-effective</property>
+        </output>
+    </filter>
 
 </PropertyList>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -707,6 +707,11 @@
             <path>/sim/model/c182s/securing/pitot-cover-visible</path>
             <path>/controls/SunVisor[0]/position-deg</path>
             <path>/controls/SunVisor[1]/position-deg</path>
+            <path>/sim/model/door-positions/DoorL/position-norm</path>
+            <path>/sim/model/door-positions/DoorR/position-norm</path>
+            <path>/sim/model/door-positions/BaggageDoor/position-norm</path>
+            <path>/sim/model/door-positions/WindowL/position-norm</path>
+            <path>/sim/model/door-positions/WindowR/position-norm</path>
         
             <path>/controls/circuit-breakers/Flap</path>
             <path>/controls/circuit-breakers/Inst</path>

--- a/c182s-sound.xml
+++ b/c182s-sound.xml
@@ -912,8 +912,8 @@
             <path>Sounds/door-closing.wav</path>
             <condition>
                 <less-than>
-                    <property>sim/model/door-positions/DoorL/position-norm</property>
-                    <value>0.5</value>
+                    <property>sim/model/door-positions/DoorL/position-norm-effective</property>
+                    <value>0.511</value>
                 </less-than>
             </condition>
             <position>
@@ -950,8 +950,8 @@
             <path>Sounds/door-closing.wav</path>
             <condition>
                 <less-than>
-                    <property>sim/model/door-positions/DoorR/position-norm</property>
-                    <value>0.5</value>
+                    <property>sim/model/door-positions/DoorR/position-norm-effective</property>
+                    <value>0.511</value>
                 </less-than>
             </condition>
             <position>
@@ -988,8 +988,8 @@
             <path>Sounds/door-closing.wav</path>
             <condition>
                 <less-than>
-                    <property>/sim/model/door-positions/BaggageDoor/position-norm</property>
-                    <value>0.06</value>
+                    <property>/sim/model/door-positions/BaggageDoor/position-norm-effective</property>
+                    <value>0.021</value>
                 </less-than>
             </condition>
             <position>

--- a/c182s.xml
+++ b/c182s.xml
@@ -1033,7 +1033,7 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>/sim/model/door-positions/DoorL/position-norm</property>
-                    <value>0.0250</value>
+                    <value>0.0150</value>
                 </product>
             </function>
             <function name="aero/coefficient/CDdoorR">
@@ -1042,7 +1042,16 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>/sim/model/door-positions/DoorR/position-norm</property>
-                    <value>0.0250</value>
+                    <value>0.0150</value>
+                </product>
+            </function>
+            <function name="aero/coefficient/CDbaggagedoor">
+                <description>Drag_due_to_door_left</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>sim/model/door-positions/BaggageDoor/position-norm</property>
+                    <value>0.0150</value>
                 </product>
             </function>
             <function name="aero/coefficient/CDwindow-l">
@@ -1051,7 +1060,7 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>/sim/model/door-positions/WindowL/position-norm</property>
-                    <value>0.0100</value>
+                    <value>0.0020</value>
                 </product>
             </function>
             <function name="aero/coefficient/CDwindow-r">
@@ -1060,7 +1069,7 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>/sim/model/door-positions/WindowR/position-norm</property>
-                    <value>0.0100</value>
+                    <value>0.0020</value>
                 </product>
             </function>
 

--- a/c182s.xml
+++ b/c182s.xml
@@ -1032,7 +1032,7 @@
                 <product>
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
-                    <property>/sim/model/door-positions/DoorL/position-norm</property>
+                    <property>/sim/model/door-positions/DoorL/position-norm-effective</property>
                     <value>0.0150</value>
                 </product>
             </function>
@@ -1041,7 +1041,7 @@
                 <product>
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
-                    <property>/sim/model/door-positions/DoorR/position-norm</property>
+                    <property>/sim/model/door-positions/DoorR/position-norm-effective</property>
                     <value>0.0150</value>
                 </product>
             </function>
@@ -1050,7 +1050,7 @@
                 <product>
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
-                    <property>/sim/model/door-positions/BaggageDoor/position-norm</property>
+                    <property>/sim/model/door-positions/BaggageDoor/position-norm-effective</property>
                     <value>0.0150</value>
                 </product>
             </function>

--- a/c182s.xml
+++ b/c182s.xml
@@ -1050,7 +1050,7 @@
                 <product>
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
-                    <property>sim/model/door-positions/BaggageDoor/position-norm</property>
+                    <property>/sim/model/door-positions/BaggageDoor/position-norm</property>
                     <value>0.0150</value>
                 </product>
             </function>


### PR DESCRIPTION
Open from PR #278 was the following:
- [x] use better drag numbers from c172p
- [x] slam shut doors above certain speed due to windforce
- [x] prevent door opening above certain airspeed
- [x] Fix drag propety for doors
- [x] produce sound when doors are closing fast
- [x] save door positions trough sessions. Make the doors close automatically in startup-modes (cruise, ready-for-takeoff, more?).

Should we port over the other two functions as well, or reimplement them in a simpler nasal approach, or skip alltogether?