### PR TITLE
Issue290 - new Option to disable temp texts; new indication of heating/cooling

### DIFF
--- a/Models/interior-model.xml
+++ b/Models/interior-model.xml
@@ -1493,11 +1493,19 @@
         <hovered>
             <binding>
                 <command>set-tooltip</command>
-                <label>Cabin Heat: %3d%%</label>
-                <measure-text>Cabin Heat: 100%</measure-text>
                 <tooltip-id>cabinheat</tooltip-id>
-                <mapping>percent</mapping>
-                <property>environment/aircraft-effects/cabin-heat-set</property>
+                <label>%s</label>
+                <property>environment/aircraft-effects/cabin-heat-set</property> <!-- currently only updating on change to the lever... :/ -->
+                <mapping>nasal</mapping>
+                <script>
+                    <![CDATA[
+                    var setting     = math.round(arg[0] * 100);
+                    var heatChange  = getprop("/fdm/jsbsim/heat/cabin-temperature-change-text") or "";
+                    if (heatChange != "") heatChange = "\n(" ~ heatChange ~ ")";
+                    var returnString = "Cabin Heat: " ~ setting ~ "%" ~ heatChange;
+                    return returnString;
+                    ]]>
+                </script>
             </binding>
         </hovered>
     </animation>
@@ -1530,11 +1538,19 @@
         <hovered>
             <binding>
                 <command>set-tooltip</command>
-                <label>Cabin Air: %3d%%</label>
-                <measure-text>Cabin Air: 100%</measure-text>
                 <tooltip-id>cabinair</tooltip-id>
-                <mapping>percent</mapping>
-                <property>environment/aircraft-effects/cabin-air-set</property>
+                <label>%s</label>
+                <property>environment/aircraft-effects/cabin-air-set</property> <!-- currently only updating on change to the lever... :/ -->
+                <mapping>nasal</mapping>
+                <script>
+                    <![CDATA[
+                    var setting     = math.round(arg[0] * 100);
+                    var heatChange  = getprop("/fdm/jsbsim/heat/cabin-temperature-change-text") or "";
+                    if (heatChange != "") heatChange = "\n(" ~ heatChange ~ ")";
+                    var returnString = "Cabin Air: " ~ setting ~ "%" ~ heatChange;
+                    return returnString;
+                    ]]>
+                </script>
             </binding>
         </hovered>
     </animation>

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -583,7 +583,7 @@ var cabin_temp_updateloop = maketimer(15.0, update_cabintemp_humidity_text); # u
 var lastTemperaturePrinted = -100; # to prevent spam with outside-spec loop; but always print the first time
 var print_cabintemp_text = func {
     # Log changed temperature feelings
-    if (getprop("/sim/model/c182s/enable-fog-frost")) {
+    if (getprop("/sim/model/c182s/enable-fog-frost") and getprop("/sim/model/c182s/enable-fog-frost-msgs")) {
         var temp      = getprop("/fdm/jsbsim/heat/cabin-air-temp-degc") or 0;
         var temp_txt  = getprop("/fdm/jsbsim/heat/cabin-temperature-text");
         if (temp_txt) {
@@ -667,7 +667,7 @@ setlistener("sim/current-view/internal", func (node) {
 
 var log_fog_frost = func {
     # log that frost/fog appeared and what to do against it
-    if (getprop("/sim/model/c182s/enable-fog-frost")) {
+    if (getprop("/sim/model/c182s/enable-fog-frost") and getprop("/sim/model/c182s/enable-fog-frost-msgs")) {
         logger.screen.white("Wait until fog/frost clears up or engage defroster or decrease cabin air temperature");
     }
 };

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -555,18 +555,34 @@ var repair_damage = func() {
 # FOG AND FROST stuff
 ###########################################
 
+var update_cabintempchange_text = func {
+    # Sets a verbally text based on temperature change.
+    var txtp = "/fdm/jsbsim/heat/cabin-temperature-change-text";
+    var chng = getprop("/fdm/jsbsim/heat/cabin-air-transfer-total") or 0;
+
+    if (chng < -3) {         setprop(txtp, "cooling down quickly");
+    } else if (chng <= -1) { setprop(txtp, "cooling down");
+    } else if (chng >= 3) {  setprop(txtp, "heating up quickly");
+    } else if (chng >= 1) {  setprop(txtp, "heating up");
+    } else {                 setprop(txtp, "");
+    }
+};
+var cabin_tempchangetxt_updateloop = maketimer(5.0, update_cabintempchange_text); # update text with some lag
+
 var update_cabintemp_humidity_text = func {
     # Sets a verbally text based on temperature.
     # TODO: should be enhanced to perceived temperature some time because humidity plays a role in the perception of temperatue
     var txtp = "/fdm/jsbsim/heat/cabin-temperature-text";
     var temp = getprop("/fdm/jsbsim/heat/cabin-air-temp-degc") or 0;
+    var tchng = getprop("/fdm/jsbsim/heat/cabin-temperature-change-text") or "";
+    if (tchng != "") tchng = " (" ~ tchng ~ ")";
 
-    if (temp < 0) {           setprop(txtp, "My fingers are freezing");
-    } else if (temp <= 10) {  setprop(txtp, "A little bit fresh here");
-    } else if (temp <= 18) {  setprop(txtp, "A little too cold here for my taste");
-    } else if (temp <= 25) {  setprop(txtp, "I feel comfortably warm now");
-    } else if (temp <= 30) {  setprop(txtp, "It is getting hot in here");
-    } else {                  setprop(txtp, "Uh, are we taking a sauna in here?");
+    if (temp < 0) {           setprop(txtp, "My fingers are freezing" ~ tchng);
+    } else if (temp <= 10) {  setprop(txtp, "A little bit fresh here" ~ tchng);
+    } else if (temp <= 18) {  setprop(txtp, "A little too cold here for my taste" ~ tchng);
+    } else if (temp <= 25) {  setprop(txtp, "I feel comfortably warm now" ~ tchng);
+    } else if (temp <= 30) {  setprop(txtp, "It is getting hot in here" ~ tchng);
+    } else {                  setprop(txtp, "Uh, are we taking a sauna in here?" ~ tchng);
     }
     
     # Sets a verbally text based on humidity.
@@ -651,6 +667,7 @@ settimer(func(){
     cabin_temp_updateloop.start();
     cabin_temp_outsideSpecComplainLoop.start();
 #    cabin_hum_outsideSpecComplainLoop.start();
+    cabin_tempchangetxt_updateloop.start();
 }, 2.0);
 
 setlistener("sim/current-view/internal", func (node) {

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -172,6 +172,7 @@
 
 <procedural-lights type="bool">true</procedural-lights>
 <enable-fog-frost type="bool">false</enable-fog-frost>
+<enable-fog-frost-msgs type="bool">true</enable-fog-frost-msgs>
 
 
 	<material>
@@ -560,6 +561,7 @@
             
             <path>/sim/time/hobbs/engine</path>
             <path>/sim/model/c182s/enable-fog-frost</path>
+            <path>/sim/model/c182s/enable-fog-frost-msgs</path>
             <path>/engines/engine/complex-engine-procedures</path>
             <path>/engines/engine/allow-fuel-contamination</path>
             <path>/engines/engine/allow-oil-management</path>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -201,6 +201,33 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
+            <group>
+                <layout>hbox</layout>
+                <!-- Small left padding -->
+                <group>
+                    <layout>vbox</layout>
+                    <padding>6</padding>
+                </group>
+                
+                <group>
+                    <layout>hbox</layout>
+                    <checkbox>
+                        <halign>left</halign>
+                        <label>  Show hint messages</label>
+                        <property>/sim/model/c182s/enable-fog-frost-msgs</property>
+                        <live>true</live>
+                        <enable>
+                            <and>
+                                <property>/sim/model/c182s/enable-fog-frost</property>
+                            </and>
+                        </enable>
+                        <binding>
+                            <command>dialog-apply</command>
+                        </binding>
+                    </checkbox>
+                </group>
+                <empty><stretch>true</stretch></empty> <!-- force group to the left -->
+            </group>
     
             <checkbox>
                 <halign>left</halign>


### PR DESCRIPTION
Solved Issue #290 
New is also a little addition that helps in temperature management.
If heating/cooling to a greater extent, it will be incorporated in the text and also on the tooltip of the air/heat levers.

![image](https://user-images.githubusercontent.com/13608602/45059700-2dd3a800-b09d-11e8-8501-720465f6b39c.png)

![image](https://user-images.githubusercontent.com/13608602/45059718-3a580080-b09d-11e8-8c1d-4a9da15049e7.png)
![image](https://user-images.githubusercontent.com/13608602/45059739-55c30b80-b09d-11e8-9ad2-66bb5436d5cc.png)
