### PR TITLE
Fix #304

### DIFF
--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -718,6 +718,28 @@ setlistener("/sim/model/c182s/fog-or-frost-increasing", func (node) {
 }, 1, 0);
 
 
+##########
+# Magneto key bindings
+# called by pressing { or } (see redefinition in c182-set.xml)
+##########
+var stepMagnetos = func(p) {
+    var keypos = getprop("/controls/switches/magnetos");
+    var magpos = getprop("controls/engines/engine/magnetos");
+    #print("stepMagnetos called with p=" ~ p ~ "; keypos=" ~ keypos ~ "; magpos=" ~ magpos);
+    
+    if (p == -1 and keypos <= 3 and keypos > 0) {
+        # mag decrease
+        var tgt_value = keypos - 1;
+        setprop("/controls/switches/magnetos", tgt_value);   # triggers an update listener
+    }
+    if (p == 1 and keypos < 3 and keypos >= 0) {
+        # mag increase
+        var tgt_value = keypos + 1;
+        setprop("/controls/switches/magnetos", tgt_value);   # triggers an update listener
+    }
+    
+}
+
 
 
 ###########

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -280,7 +280,7 @@ var updateMagnetos = func() {
         tgt_value = keypos;
     }
     
-    setprop("controls/engines/engine/magnetos", tgt_value);
+    setprop("controls/engines/engine/magnetos", tgt_value); # value for internal engine state
     #setprop("/engines/engine/magnetos", keypos); # this property seems not to be used!
 }
 setlistener("/controls/switches/magnetos", updateMagnetos, 1, 1);

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -1082,6 +1082,37 @@
           <property>sim/model/hide-yoke</property>
         </binding>
       </key>    
+      
+      
+      <!-- overwriting { and } default aliases -->
+      <key n="123">
+        <name>{</name>
+        <desc>Decrease Magneto on Selected Engine</desc>
+        <binding>
+            <command>nasal</command>
+            <script>c182s.stepMagnetos(-1)</script>
+        </binding>
+        <mod-up>
+            <binding>
+                <command>nasal</command>
+                <script>c182s.stepMagnetos(0)</script>
+            </binding>
+        </mod-up>
+      </key>
+      <key n="125">
+        <name>}</name>
+        <desc>Increase Magneto on Selected Engine</desc>
+        <binding>
+            <command>nasal</command>
+                <script>c182s.stepMagnetos(1)</script>
+        </binding>
+        <mod-up>
+            <binding>
+                <command>nasal</command>
+                <script>c182s.stepMagnetos(0)</script>
+            </binding>
+        </mod-up>
+      </key>
 
     </keyboard>
     </input>


### PR DESCRIPTION
Fix was to override the default magneto key bindings with custom ones that trigger the internal update function. This way one also cannot override faulty magnetos anymore.

Tested and ready for merge in my opinion.