### PR TITLE
Refactored calculation of COM1/2 radio power-btn to electrical.xml

### DIFF
--- a/Models/Instruments/Avionics/kx165-1.xml
+++ b/Models/Instruments/Avionics/kx165-1.xml
@@ -690,6 +690,7 @@
                 <max>1.0</max>
                 <wrap>false</wrap>
             </binding>
+            <!-- moved to Systems/electrical.xml so it can be calculated depending on available power/serviceable etc
             <binding>
                 <command>property-assign</command>
                 <property alias="../../../../params/power-comm"/>
@@ -712,6 +713,7 @@
                     </less-than>
                 </condition>
             </binding>
+            -->
             <binding>
                 <command>property-assign</command>
                 <property alias="../../../../params/power-nav"/>

--- a/Models/Instruments/Avionics/kx165-1.xml
+++ b/Models/Instruments/Avionics/kx165-1.xml
@@ -690,30 +690,6 @@
                 <max>1.0</max>
                 <wrap>false</wrap>
             </binding>
-            <!-- moved to Systems/electrical.xml so it can be calculated depending on available power/serviceable etc
-            <binding>
-                <command>property-assign</command>
-                <property alias="../../../../params/power-comm"/>
-                <value>1</value>
-                <condition>
-                    <greater-than>
-                        <property alias="../../../../../../params/comm-volume"/>
-                        <value>0.05</value>
-                    </greater-than>
-                </condition>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property alias="../../../../params/power-comm"/>
-                <value>0</value>
-                <condition>
-                    <less-than>
-                        <property alias="../../../../../../params/comm-volume"/>
-                        <value>0.05</value>
-                    </less-than>
-                </condition>
-            </binding>
-            -->
             <binding>
                 <command>property-assign</command>
                 <property alias="../../../../params/power-nav"/>

--- a/Models/Instruments/Avionics/kx165-2.xml
+++ b/Models/Instruments/Avionics/kx165-2.xml
@@ -689,30 +689,6 @@
                 <max>1.0</max>
                 <wrap>false</wrap>
             </binding>
-            <!-- moved to Systems/electrical.xml so it can be calculated depending on available power/serviceable etc
-            <binding>
-                <command>property-assign</command>
-                <property alias="../../../../params/power-comm"/>
-                <value>1</value>
-                <condition>
-                    <greater-than>
-                        <property alias="../../../../../../params/comm-volume"/>
-                        <value>0.05</value>
-                    </greater-than>
-                </condition>
-            </binding>
-            <binding>
-                <command>property-assign</command>
-                <property alias="../../../../params/power-comm"/>
-                <value>0</value>
-                <condition>
-                    <less-than>
-                        <property alias="../../../../../../params/comm-volume"/>
-                        <value>0.05</value>
-                    </less-than>
-                </condition>
-            </binding>
-            -->
             <binding>
                 <command>property-assign</command>
                 <property alias="../../../../params/power-nav"/>

--- a/Models/Instruments/Avionics/kx165-2.xml
+++ b/Models/Instruments/Avionics/kx165-2.xml
@@ -689,6 +689,7 @@
                 <max>1.0</max>
                 <wrap>false</wrap>
             </binding>
+            <!-- moved to Systems/electrical.xml so it can be calculated depending on available power/serviceable etc
             <binding>
                 <command>property-assign</command>
                 <property alias="../../../../params/power-comm"/>
@@ -711,6 +712,7 @@
                     </less-than>
                 </condition>
             </binding>
+            -->
             <binding>
                 <command>property-assign</command>
                 <property alias="../../../../params/power-nav"/>

--- a/Nasal/c182s-states.nas
+++ b/Nasal/c182s-states.nas
@@ -32,8 +32,6 @@ var setAvionics = func(state) {
     setprop("/controls/switches/kn-62a", state);
     setprop("/instrumentation/nav[0]/power-btn", state);
     setprop("/instrumentation/nav[1]/power-btn", state);
-    setprop("/instrumentation/comm[0]/power-btn", state);
-    setprop("/instrumentation/comm[1]/power-btn", state);
     setprop("/instrumentation/comm[0]/volume-selected", state);
     setprop("/instrumentation/comm[1]/volume-selected", state);
     setprop("/controls/switches/kn-62a-mode", state);

--- a/Systems/electrical.xml
+++ b/Systems/electrical.xml
@@ -32,4 +32,28 @@
           <output>/systems/electrical/battery-capacity-factor</output>   
         </fcs_function>
     </channel>
+    
+    
+    <!-- Calculate COM1/2 power button states depending on serviceable, power and volume knob.
+         (This is useful for FGCom and common ATC integrations)  -->
+    <channel name="com_power_buttons">
+        <switch name="com1_power-btn">
+            <output>/instrumentation/comm[0]/power-btn</output>   
+            <default value="0"/>
+            <test value="1">
+                /instrumentation/comm[0]/volume-selected > 0.05
+                /instrumentation/comm[0]/serviceable == 1
+                /systems/electrical/outputs/comm[0]  >= 22
+            </test>
+        </switch>
+        <switch name="com2_power-btn">
+            <output>/instrumentation/comm[1]/power-btn</output>   
+            <default value="0"/>
+            <test value="1">
+                /instrumentation/comm[1]/volume-selected > 0.05
+                /instrumentation/comm[1]/serviceable == 1
+                /systems/electrical/outputs/comm[1]  >= 22
+            </test>
+        </switch>
+    </channel>
 </system>


### PR DESCRIPTION
The reason was that the `power-btn` property was changed only by turning the knob.

However other scripts (like Red Griffin ATC) rely on it to get the "radio is turned on"-state.
The power-btn of com1/2 is now calculated and considered "on" when not only the knob is turned,
but also the radio is serviceable and has electrical power.