### PR TITLE
Small fixes for 2020.2

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -280,8 +280,10 @@ var updateMagnetos = func() {
         tgt_value = keypos;
     }
     
-    setprop("controls/engines/engine/magnetos", tgt_value); # value for internal engine state
-    #setprop("/engines/engine/magnetos", keypos); # this property seems not to be used!
+    if (tgt_value != nil) {
+        setprop("controls/engines/engine/magnetos", tgt_value); # value for internal engine state
+        #setprop("/engines/engine/magnetos", keypos); # this property seems not to be used!
+    }
 }
 setlistener("/controls/switches/magnetos", updateMagnetos, 1, 1);
 setlistener("/controls/engines/engine/faults/left-magneto-serviceable", updateMagnetos, 0, 1);

--- a/Systems/electrical.xml
+++ b/Systems/electrical.xml
@@ -6,6 +6,8 @@
     <property type="double" value="0">/systems/electrical/volts</property>
     <property type="double" value="0">/systems/electrical/outputs/flaps</property>
     <property type="double" value="0">/systems/electrical/outputs/pitot-heat</property>
+    <property type="double" value="0">/systems/electrical/outputs/comm[0]</property>
+    <property type="double" value="0">/systems/electrical/outputs/comm[1]</property>
 
     <!-- the electrical system is implemented in electrical.nas! -->
 


### PR DESCRIPTION
- Fix 2020.02 startup error complaining about missing `electrical/output/comm[n]` nodes
- Fix nasal magnetos selector error (was cosmetical)