### PR TITLE
Issue 343 flaps operation + lights consume power

### DIFF
--- a/Nasal/c182s-electrical.nas
+++ b/Nasal/c182s-electrical.nas
@@ -626,6 +626,7 @@ var IL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/instrument-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/instrument-light-serviceable") ){
 	setprop("/systems/electrical/outputs/instrument-lights",IL_DIMMER);
 	setprop("/systems/electrical/outputs/instrument-lights-norm",IL_DIMMER/24);
+	load += IL_DIMMER/24;
 	}else{
 	setprop("/systems/electrical/outputs/instrument-lights",0);
 	setprop("/systems/electrical/outputs/instrument-lights-norm",0);
@@ -638,6 +639,7 @@ var GL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/glareshield-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/cabin-light-serviceable")){
 	setprop("/systems/electrical/outputs/glareshield-lights",GL_DIMMER);
 	setprop("/systems/electrical/outputs/glareshield-lights-norm",GL_DIMMER/28);
+	load += GL_DIMMER/28
 	}else{
 	setprop("/systems/electrical/outputs/glareshield-lights",0);
 	setprop("/systems/electrical/outputs/glareshield-lights-norm",0);
@@ -650,6 +652,7 @@ var PL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/pedestal-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/cabin-light-serviceable")){
 	setprop("/systems/electrical/outputs/pedestal-lights",PL_DIMMER);
 	setprop("/systems/electrical/outputs/pedestal-lights-norm",PL_DIMMER/28);
+	load += PL_DIMMER/28
 	}else{
 	setprop("/systems/electrical/outputs/pedestal-lights",0);
 	setprop("/systems/electrical/outputs/pedestal-lights-norm",0);
@@ -664,6 +667,7 @@ var RL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/radio-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/instrument-light-serviceable")){
 	setprop("/systems/electrical/outputs/radio-lights",RL_DIMMER);
 	setprop("/systems/electrical/outputs/radio-lights-norm",RL_DIMMER/24);
+	load += RL_DIMMER/24
 	}else{
 	setprop("/systems/electrical/outputs/radio-lights",0);
 	setprop("/systems/electrical/outputs/radio-lights-norm",0);

--- a/Nasal/c182s-electrical.nas
+++ b/Nasal/c182s-electrical.nas
@@ -472,7 +472,7 @@ else {
 
 
     # Flaps Power
-    if ( getprop("/controls/circuit-breakers/Flap") ) {
+    if ( getprop("/controls/circuit-breakers/Flap") and getprop("/sim/failure-manager/controls/flight/flaps/serviceable") ) {
         setprop("/systems/electrical/outputs/flaps", bus_volts);
         load += bus_volts / 2;
     } else {

--- a/Nasal/c182s-electrical.nas
+++ b/Nasal/c182s-electrical.nas
@@ -474,7 +474,9 @@ else {
     # Flaps Power
     if ( getprop("/controls/circuit-breakers/Flap") and getprop("/sim/failure-manager/controls/flight/flaps/serviceable") ) {
         setprop("/systems/electrical/outputs/flaps", bus_volts);
-        load += bus_volts / 2;
+        if (getprop("/systems/electrical/flaps/actuator-moving") ) {
+            load += bus_volts / 2;
+        }
     } else {
         setprop("/systems/electrical/outputs/flaps", 0.0);
     }

--- a/Nasal/c182t-electrical.nas
+++ b/Nasal/c182t-electrical.nas
@@ -472,9 +472,11 @@ else {
 
 
     # Flaps Power
-    if ( getprop("/controls/circuit-breakers/Flap") ) {
+    if ( getprop("/controls/circuit-breakers/Flap") and getprop("/sim/failure-manager/controls/flight/flaps/serviceable") ) {
         setprop("/systems/electrical/outputs/flaps", bus_volts);
-        load += bus_volts / 2;
+        if (getprop("/systems/electrical/flaps/actuator-moving") ) {
+            load += bus_volts / 2;
+        }
     } else {
         setprop("/systems/electrical/outputs/flaps", 0.0);
     }
@@ -624,6 +626,7 @@ var IL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/instrument-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/instrument-light-serviceable") ){
 	setprop("/systems/electrical/outputs/instrument-lights",IL_DIMMER);
 	setprop("/systems/electrical/outputs/instrument-lights-norm",IL_DIMMER/24);
+	load += IL_DIMMER/24;
 	}else{
 	setprop("/systems/electrical/outputs/instrument-lights",0);
 	setprop("/systems/electrical/outputs/instrument-lights-norm",0);
@@ -636,6 +639,7 @@ var GL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/glareshield-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/cabin-light-serviceable")){
 	setprop("/systems/electrical/outputs/glareshield-lights",GL_DIMMER);
 	setprop("/systems/electrical/outputs/glareshield-lights-norm",GL_DIMMER/28);
+	load += GL_DIMMER/28;
 	}else{
 	setprop("/systems/electrical/outputs/glareshield-lights",0);
 	setprop("/systems/electrical/outputs/glareshield-lights-norm",0);
@@ -648,6 +652,7 @@ var PL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/pedestal-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/cabin-light-serviceable")){
 	setprop("/systems/electrical/outputs/pedestal-lights",PL_DIMMER);
 	setprop("/systems/electrical/outputs/pedestal-lights-norm",PL_DIMMER/28);
+	load += PL_DIMMER/28;
 	}else{
 	setprop("/systems/electrical/outputs/pedestal-lights",0);
 	setprop("/systems/electrical/outputs/pedestal-lights-norm",0);
@@ -662,6 +667,7 @@ var RL_DIMMER = (getprop("/systems/electrical/outputs/ecrf")) * (getprop("contro
 	if (getprop ("/controls/lighting/radio-lights-norm") >0.05 and (bus_volts > 22) and getprop("/systems/electrical/instrument-light-serviceable")){
 	setprop("/systems/electrical/outputs/radio-lights",RL_DIMMER);
 	setprop("/systems/electrical/outputs/radio-lights-norm",RL_DIMMER/24);
+	load += RL_DIMMER/24;
 	}else{
 	setprop("/systems/electrical/outputs/radio-lights",0);
 	setprop("/systems/electrical/outputs/radio-lights-norm",0);

--- a/Systems/electrical.xml
+++ b/Systems/electrical.xml
@@ -8,6 +8,8 @@
     <property type="double" value="0">/systems/electrical/outputs/pitot-heat</property>
     <property type="double" value="0">/systems/electrical/outputs/comm[0]</property>
     <property type="double" value="0">/systems/electrical/outputs/comm[1]</property>
+    <property type="double" value="0">/systems/electrical/flaps/actuator-cmd-diff</property>
+    <property type="bool"   value="0">/systems/electrical/flaps/actuator-moving</property>
 
     <!-- the electrical system is implemented in electrical.nas! -->
 
@@ -58,4 +60,30 @@
             </test>
         </switch>
     </channel>
+
+    <!-- Detect flap actuators moving (or commanded to move) -->
+    <channel name="flaps_actuator">
+        <fcs_function name="/systems/electrical/flaps/actuator-cmd-diff">
+            <!-- we calculate the difference of the commanded and the actual value
+                to see if there is movement neccessary -->
+            <function>
+                <abs>
+                    <difference>
+                        <property>/fdm/jsbsim/fcs/flap-cmd-norm</property>
+                        <property>/fdm/jsbsim/fcs/flap-pos-norm</property>
+                    </difference>
+                </abs>
+            </function>
+            <output>/systems/electrical/flaps/actuator-cmd-diff</output>
+        </fcs_function>
+
+        <switch name="flaps_actuator_moving">
+            <output>/systems/electrical/flaps/actuator-moving</output>
+            <default value="0"/>
+            <test value="1">
+                /systems/electrical/flaps/actuator-cmd-diff > 0.005
+            </test>
+        </switch>
+    </channel>
+
 </system>


### PR DESCRIPTION
Operating the flap actuators as well as turning on radio lights or glareshield consume electrical power, showing on the ammeter