### PR TITLE
Simulate spark plug icing

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -44,6 +44,8 @@ Otherwise you need to pay attention to varios engine related things:
   the oil pump will not be able to supply enough pressure for good lubrication, leading to engine failure. Also monitor the oil service time as
   old oil does not perform so well (cycle it about every 50 hrs).
   Also some effects like additional friction with too hot oil and cold-start will be simulated.
+- `Allow Spark plug icing`  
+  If active, the spark plugs can freeze over, preventing engine start. This can occur in cold weather if the engine starts and quits shortly after, because then the engine is still cold, letting the water produced by the combustion process condensate on the plugs where they freeze over. This will prevent furter engine starts. To prevent this, preheat the engine properly, and if it happened, heat the engine so the ice melts (which can take considerable time!)
 - `Winter Kit`  
   The winter kit is needed in cold weather (<20°F/-6°C) to reduce cooling air flow. If not supplied, the engine will possibly not get warm enough to develop good power, but be sure to remove it in hot weather, otherwise you risk too high CHT temps.
 

--- a/Nasal/damage.nas
+++ b/Nasal/damage.nas
@@ -131,6 +131,7 @@ var repair_damage = func() {
 
     setprop("/engines/engine[0]/kill-engine", 0.0);
     setprop("/engines/engine[0]/crashed", 0.0);
+    setprop("/systems/fuel/engine-sparkplugs-iced", 0.0);
     electrical.reset_battery_and_circuit_breakers();
     FailureMgr.repair_all();
     for (var tankID=0; tankID <= 5; tankID = tankID+1) {

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -233,6 +233,76 @@ var calculate_real_oiltemp = maketimer(0.5, func {
     }
 });
 
+# ======= CHT temperature jsbsim compensator =======
+# Currently, jsbsim CHT temperature always initializes at 60°F.
+# We want an temperature that initialise to environment temperature until first start
+# and then gradually switch over to the real jsbsim value after some time.
+var calculate_real_chttemp = maketimer(0.5, func {
+    if (!getprop("/engines/engine/already-started-in-session")) {
+        # engine is still cold
+        var temp_env        = getprop("/environment/temperature-degf") or 60;
+        var temp_jsbsim_cht = getprop("/engines/engine/cht-degf") or 60;
+        current_temp_diff   = temp_jsbsim_cht - temp_env;
+        setprop("/engines/engine/cht-temperature-env-diff", current_temp_diff);
+    } else {
+        # engine has been startet at least one time:
+        # gradually remove the difference as jsbsim adapts to real environment temperature
+        calculate_real_chttemp.stop();
+        interpolate("/engines/engine/cht-temperature-env-diff", 0, 10); # hand over to jsbsim caluclation gradually
+    }
+});
+
+# ======== Spark plug icing simulation =========
+# When engine halts, checks if spark plug icing occurs
+# This can occur if the spark plug temp is below freezing temps and the engine stops.
+# Burnt fuel will produce small ammounts of water vapor which then freezes over
+# the still cold metal, shorting the elec and no spark will appear anymore.
+var sparkPlugIcingMeltingHandler = maketimer(1, func(){
+    # Simulate spark plug ice melting (like from resident or environment heat, or heater)
+    #print("spark plug ice melt handler called.");
+    var cht_temp = getprop("/engines/engine/cht-compensated-temperature-degf");
+    var icelevel = getprop("/systems/fuel/engine-sparkplugs-iced");
+    
+    # calculate melting
+    var tempAboveZero = cht_temp - 32.0;
+    if (tempAboveZero > 0.0) {
+        var meltRate = math.pow(tempAboveZero,2)/(250000); # decimal-percent per second
+                       # ^^ gives about 1,6min @50°F/26°C above zero
+                       # ^^ gives about 4min @30°F/13°C above zero
+                       # ^^ gives about 16min @15°F/6°C above zero
+        if (meltRate > 0.01) meltRate = 0.01;  # don't melt faster 
+
+        #print("spark plug ice melt rate pctpts/s =" ~ meltRate ~ "; level="~icelevel);
+        icelevel = icelevel - meltRate;
+        setprop("/systems/fuel/engine-sparkplugs-iced", icelevel);
+    }
+    
+    
+    # All ice is gone, or simulation is disabled at runtime
+    var allow_complex_engine_procs = getprop("/engines/engine/complex-engine-procedures");
+    var allow_sparkplugicing       = getprop("/engines/engine/allow-sparkplug-icing");
+    if (icelevel < 0.01 or !allow_complex_engine_procs or !allow_sparkplugicing ) {
+        setprop("/systems/fuel/engine-sparkplugs-iced", 0.0);
+        sparkPlugIcingMeltingHandler.stop();
+        #print("spark plug ice melt handler stopped.");
+    }
+});
+sparkPlugIcingMeltingHandler.simulatedTime = 1;
+
+var applySparkPlugicing = func() {
+    # called on engine halt to check if icing occurs.
+    # We need an approximation for the plugs temperature
+    var sparkPlugTemp = getprop("/engines/engine/sparkplugs-temperature-degf");
+    if (sparkPlugTemp <= 32.0) {
+        # If the plug is frosty, water from the combustion process will condense and freeze over.
+        setprop("/systems/fuel/engine-sparkplugs-iced", 1);
+        print("Spark plugs iced!");
+        sparkPlugIcingMeltingHandler.start();
+    }
+}
+
+
+
 # ======= OIL Pump handling =====
 setlistener("/engines/engine[0]/oil-pump/serviceable", func {
     svc = getprop("/engines/engine[0]/oil-pump/serviceable");
@@ -254,6 +324,7 @@ if (!getprop("/engines/engine[0]/oil-service-hours")) {
 oil_consumption.simulatedTime = 1;
 oil_consumption.start();
 calculate_real_oiltemp.start();
+calculate_real_chttemp.start();
 
 
 # ======= Magneto handling ======
@@ -304,6 +375,12 @@ setlistener("/engines/engine/running", func(ngn){
     } else {
         engine_starting.setValue(0);
     }
+    
+    # Engine stopped
+    if (!ngn.getValue()) {
+        applySparkPlugicing(); # Spark plug icing: check if it occurs if engine stops
+    }
+    
 },0,0);
 
 setlistener("/engines/engine/starting", func(ngn){

--- a/Systems/external-heat.xml
+++ b/Systems/external-heat.xml
@@ -69,6 +69,12 @@ Author: 12/2017  Benedikt Hallinger
             <input>-/engines/engine/oil-temperature-env-diff</input>
             <output>/engines/engine/oil-compensated-temperature-degf</output>
         </summer>
+        <summer name="CHT compensated environment Temperature">
+            <input>/engines/engine/cht-degf</input>
+            <input>-/engines/engine/cht-temperature-env-diff</input>
+            <input>/engines/engine/external-heat/applied-degF</input>
+            <output>/engines/engine/cht-compensated-temperature-degf</output>
+        </summer>
     </channel>
 
 </system>

--- a/Systems/fuel.xml
+++ b/Systems/fuel.xml
@@ -46,6 +46,8 @@ Author: 09/2017  Benedikt Hallinger
     <property type="double" value="1">/controls/engines/engine/mixture-maxaltitude</property>
     <property type="bool" value="0">/systems/fuel/engine-primed</property>
     <property type="bool" value="0">/systems/fuel/engine-flooded</property>
+    
+    <property type="double" value="0">/systems/fuel/engine-sparkplugs-iced</property>
 
     <!-- now defined in instruments.xml filter: <property type="double" value="0">/systems/fuel/indicated-manfold-fuel-flow-gph</property>-->
 
@@ -463,6 +465,7 @@ Author: 09/2017  Benedikt Hallinger
                     <!-- engine flooded or not primed correctly: manifold closed -->
                     /systems/fuel/engine-flooded  EQ  1
                     /systems/fuel/engine-primed  EQ  0
+                    /systems/fuel/engine-sparkplugs-iced  GT 0.1
                 </test>
             </test>
             <output>/fdm/jsbsim/propulsion/tank[5]/priority</output>

--- a/Systems/propulsion.xml
+++ b/Systems/propulsion.xml
@@ -133,6 +133,29 @@
         </fcs_function>
 
  </channel>
+ 
+
+<channel name="sparkPlugs">
+    <!-- Calculates an approximated spark plug temperature -->
+    <!-- this is currently not really close, but we need it just for the spark plug icing for now.
+        the reasoning is: CHT is directly exposed to the combustion, thus heats very quickly.
+        We need however the temperature at the spark plug, which gets cooled indicrectly from the oil and
+        engine block, thus reacts slower to temperature changes (but quicker than the oil).
+    -->
+    <fcs_function name="/engines/engine/sparkplugs-temperature-degf">
+        <description>Simulates Spark plug temperature</description>
+        <function>
+            <quotient>
+                <sum>
+                    <property>/engines/engine/oil-final-temperature-degf</property>
+                    <property>/engines/engine/cht-compensated-temperature-degf</property>
+                </sum>
+                <value>2</value>
+            </quotient>
+        </function>
+    </fcs_function>
+
+</channel>
     
     <!-- Engine friction depending on Oil parameters
          with credits and many thanks to Ron Jensen: https://sourceforge.net/p/jsbsim/mailman/message/30264774/

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -800,6 +800,7 @@
             <path>/engines/engine/complex-engine-procedures</path>
             <path>/engines/engine/allow-fuel-contamination</path>
             <path>/engines/engine/allow-oil-management</path>
+            <path>/engines/engine/allow-sparkplug-icing</path>
             <path>/engines/engine/winter-kit-installed</path>
             
             <path>/fdm/jsbsim/settings/damage</path>
@@ -1156,6 +1157,7 @@
    <allow-oil-management type="bool">false</allow-oil-management>
    <winter-kit-installed type="bool">false</winter-kit-installed>
    <oil-temperature-env-diff type="double">0</oil-temperature-env-diff>
+   <allow-sparkplug-icing type="bool">false</allow-sparkplug-icing>
    <oil-compensated-temperature-degf type="double">60</oil-compensated-temperature-degf>
    <external-heat>
        <enabled type="bool">false</enabled>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -793,6 +793,7 @@
             <path>/engines/engine/complex-engine-procedures</path>
             <path>/engines/engine/allow-fuel-contamination</path>
             <path>/engines/engine/allow-oil-management</path>
+            <path>/engines/engine/allow-sparkplug-icing</path>
             <path>/engines/engine/winter-kit-installed</path>
 
             <path>/fdm/jsbsim/settings/damage</path>
@@ -1123,6 +1124,7 @@
    <complex-engine-procedures type="bool">false</complex-engine-procedures>
    <allow-fuel-contamination type="bool">false</allow-fuel-contamination>
    <allow-oil-management type="bool">false</allow-oil-management>
+   <allow-sparkplug-icing type="bool">false</allow-sparkplug-icing>
    <winter-kit-installed type="bool">false</winter-kit-installed>
    <oil-temperature-env-diff type="double">0</oil-temperature-env-diff>
    <oil-compensated-temperature-degf type="double">60</oil-compensated-temperature-degf>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -326,7 +326,36 @@
                 <empty><stretch>true</stretch></empty> <!-- force group to the left -->
             </group>
             
+            <group>
+                <layout>hbox</layout>
+                <!-- Small left padding -->
+                <group>
+                    <layout>vbox</layout>
+                    <padding>6</padding>
+                </group>
+
+                <group>
+                    <layout>hbox</layout>
+                    <checkbox>
+                        <halign>left</halign>
+                        <label>  Allow Spark plug icing</label>
+                        <property>/engines/engine/allow-sparkplug-icing</property>
+                        <live>true</live>
+                        <enable>
+                            <and>
+                                <property>/engines/engine/complex-engine-procedures</property>
+                            </and>
+                        </enable>
+                        <binding>
+                            <command>dialog-apply</command>
+                        </binding>
+                    </checkbox>
+                </group>
                 
+                <empty><stretch>true</stretch></empty> <!-- force group to the left -->
+            </group>
+            
+            
         </group>
         
         <checkbox>


### PR DESCRIPTION
This adds simulation of spark plug icing (enable it in the aircraft dialog!)
Spark plug icing will prevent starting of the engine. It can occur if the engine does not get warm enough, ie. if it dies in cold weather directly after starting.

When this occurs the spark plugs are frozen over, because the water product from the combustion will condensate on the still-freezingly cold plugs and thus short the electric gap which normally provides the spark to ignite the fuel.

It can be remedied by applying preheater to melt the ice, but this takes a long time usually.
It's way better to take precautions (eg preheat the engine if it is below freezing temperatures).

(fix #274)