### PR TITLE
KAP-140: Fixes

### DIFF
--- a/Systems/KAP140.xml
+++ b/Systems/KAP140.xml
@@ -8,9 +8,57 @@
 <PropertyList>
 
     <filter>
+        <name>heading bug backcourse</name>
+        <debug>false</debug>
+        <type>gain</type>
+        <input>
+            <condition>
+                <less-than>
+                    <property>autopilot/settings/heading-bug-deg</property>
+                    <value>180</value>
+                </less-than>
+            </condition>
+            <expression>
+                <sum>
+                    <property>autopilot/settings/heading-bug-deg</property>
+                    <value>180</value>
+                </sum>
+            </expression>
+        </input>
+        <input>
+            <expression>
+                <sum>
+                    <value>-180</value>
+                    <property>autopilot/settings/heading-bug-deg</property>
+                </sum>
+            </expression>
+        </input>
+        <output>
+            <property>autopilot/settings/heading-bug-deg-backcourse</property>
+        </output>
+    </filter>
+    
+    <filter>
         <name>heading bug error computer/normalizer</name>
         <debug>false</debug>
         <type>gain</type>
+        
+        <!-- REV mode -->
+        <input>
+            <condition>
+                <equals>
+                    <property>/autopilot/KAP140/locks/rev-hold</property>
+                    <value type="bool">true</value>
+                </equals>
+            </condition>
+            <property>autopilot/settings/heading-bug-deg-backcourse</property>
+            <offset>
+                <property>instrumentation/heading-indicator/indicated-heading-deg</property>
+                <scale>-1.0</scale>
+            </offset>
+        </input>
+        
+        <!-- Other modes -->
         <input>
             <property>autopilot/settings/heading-bug-deg</property>
             <offset>


### PR DESCRIPTION
- [x] Fix #369: REV mode did not work: The manual says, we need to dial in the FRONT INBOUND course to the HDG-Bug (and also OBS on VORs)
- [x] ALT ARM bug: ALT-ARM is possible with disabled AP (-> is a core isse https://sourceforge.net/p/flightgear/codetickets/2489/)
- [x] Enable switching between modes NAV/APR/REV (-> is a core issue https://sourceforge.net/p/flightgear/codetickets/2488/)
<s>- [ ] Enforce BARO setting after startup sequence</s>
<s>- [ ] (maybe: implement startup sequence after PWR-ON? we could do that pretty simple probably with an Nasal/Canvas combo)</s>
<s> -[ ] fix oszillation when heading INBOUND to a VOR </s>(see: #372)