### PR TITLE
Optional transparent yoke-hiding for c182s/t

### DIFF
--- a/Models/interior-model-c182s.xml
+++ b/Models/interior-model-c182s.xml
@@ -764,15 +764,13 @@
         </hovered>
     </animation>
     
- <animation>
-        <type>select</type>
+    <animation>
+        <type>material</type>
         <object-name>Yoke.L</object-name>
         <object-name>Yoke.R</object-name>
-        <condition>
-            <not>
-                <property>sim/model/hide-yoke</property>
-            </not>
-        </condition>
+        <transparency>
+            <alpha-prop>sim/model/hide-yoke-alpha</alpha-prop>
+        </transparency>
     </animation>
     
 <animation>

--- a/Models/interior-model-c182t.xml
+++ b/Models/interior-model-c182t.xml
@@ -705,15 +705,13 @@
         </hovered>
     </animation>
 
- <animation>
-        <type>select</type>
+    <animation>
+        <type>material</type>
         <object-name>Yoke.L</object-name>
         <object-name>Yoke.R</object-name>
-        <condition>
-            <not>
-                <property>sim/model/hide-yoke</property>
-            </not>
-        </condition>
+        <transparency>
+            <alpha-prop>sim/model/hide-yoke-alpha</alpha-prop>
+        </transparency>
     </animation>
 
 <animation>

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -767,6 +767,24 @@ var updateSeatPosition = func(ammount_in_m=0) {
 }
 updateSeatPosition(); # init seat position
 
+
+##########
+# Handle Yoke transparency
+##########
+var updateYokeTransparency = func() {
+    var hide = getprop("/sim/model/hide-yoke") or 0;
+    if (hide == 1) {
+        alpha = getprop("sim/model/hide-yoke-alpha-cmd");
+    } else {
+        alpha = 1;
+    }
+    setprop("/sim/model/hide-yoke-alpha", alpha);
+}
+setlistener("/sim/model/hide-yoke", updateYokeTransparency, 1, 0);
+setlistener("/sim/model/hide-yoke-alpha-cmd", updateYokeTransparency, 1, 0);
+
+
+
 ###########
 # INIT of Aircraft
 # (states are initialized in separate nasal script!)

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -275,7 +275,8 @@
   <model include="Models/Human/humans.xml">
     <fallback-model-index>3</fallback-model-index>
    <path archive="y">Aircraft/c182s/Models/c182s.xml</path>
-    <hide-yoke>false</hide-yoke>
+    <hide-yoke type="bool">false</hide-yoke>
+    <hide-yoke-alpha-cmd>0.25</hide-yoke-alpha-cmd>
 
      <icing>
         <iceable>
@@ -1038,6 +1039,7 @@
 
             <path>/sim/failure-manager/display-on-screen</path>
             <path>/sim/failure-manager/restore-on-start</path>
+            <path>/sim/model/hide-yoke-alpha-cmd</path>
         </aircraft-data>
 
      <flight-recorder include="Systems/flight-recorder/flight-recorder.xml"/>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -271,7 +271,8 @@
   <model include="Models/Human/humans.xml">
    <path archive="y">Aircraft/c182s/Models/c182t.xml</path>
    <fallback-model-index>3</fallback-model-index>
-   <hide-yoke>false</hide-yoke>
+   <hide-yoke type="bool">false</hide-yoke>
+   <hide-yoke-alpha-cmd>0.25</hide-yoke-alpha-cmd>
 
     <icing>
        <iceable>
@@ -986,6 +987,7 @@
 
             <path>/sim/failure-manager/display-on-screen</path>
             <path>/sim/failure-manager/restore-on-start</path>
+            <path>/sim/model/hide-yoke-alpha-cmd</path>
         </aircraft-data>
 
  </sim>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -537,19 +537,36 @@
 <group>
 	<layout>vbox</layout>
 	<padding>6</padding>
-	<checkbox>
+    
+        <group>
+            <layout>hbox</layout>
+            <halign>left</halign>
+            
+            <checkbox>
                 <halign>left</halign>
                 <label>Show/Hide Yokes</label>
-                    <property>/sim/model/hide-yoke</property>
+                <property>/sim/model/hide-yoke</property>
                 <live>true</live>
                 <binding>
                     <command>property-toggle</command>
                     <property>/sim/model/hide-yoke</property>
                 </binding>
-	<binding>
+                <binding>
                     <command>dialog-update</command>
                 </binding>
-	</checkbox>
+            </checkbox>
+            <slider>
+                <name>c182-yokealpha-slider</name>
+                <min>0</min>
+                <max>1.0</max>
+                <live>true</live>
+                <property>/sim/model/hide-yoke-alpha-cmd</property>
+                <binding>
+                    <command>dialog-apply</command>
+                    <name>c182-yokealpha-slider</name>
+                </binding>
+            </slider>
+        </group>
 
             <checkbox>
                 <halign>left</halign>


### PR DESCRIPTION
Over the past years I had the issue (here and there) that i had the yoke hidden to be able to read the instruments/knobs for takeoff and sometimes I was not centered by accident which gave bad takeoffs.

Today this idea struck my mind and I think it improves the user experience alot, since now we are able to see the stuff behind the yoke _and_ being able to see where the yoke is :grin: 

Users might tune the transparency setting to their liking (between fully-transparent to fully-opaque), and the setting is saved and restored across sessions.

----

![grafik](https://user-images.githubusercontent.com/13608602/110207830-354eb480-7e86-11eb-98db-f5c813927b12.png)

![grafik](https://user-images.githubusercontent.com/13608602/110207919-4d263880-7e86-11eb-98a8-4a9cce47f032.png)

![grafik](https://user-images.githubusercontent.com/13608602/110207934-69c27080-7e86-11eb-8248-7e5564517602.png)


![grafik](https://user-images.githubusercontent.com/13608602/110207950-8363b800-7e86-11eb-9886-090f4bf159a9.png)
