### PR TITLE
KAP-140: added better ROL all-angle-intercept activation

### DIFF
--- a/Models/Instruments/Avionics/kap140/kap140-autopilot.xml
+++ b/Models/Instruments/Avionics/kap140/kap140-autopilot.xml
@@ -109,6 +109,50 @@
 	</filter>
 	
 	<filter>
+		<name>DG HeadingBug latch actual heading error</name>
+		<type>gain</type>
+		<gain>1.0</gain>
+		<input>
+			<condition>
+				<not><property>/autopilot/kap140/config/hsi-installed</property></not>
+				<or>
+					<property>/autopilot/internal/logic/rev-active</property>
+					<equals>
+						<property>autopilot/kap140/settings/lateral-arm</property>
+						<value>5</value>
+					</equals>
+				</or>
+			</condition>
+			<property>/autopilot/settings/heading-bug-latch</property>
+			<offset>
+				<expression>
+					<sum>
+						<value>180</value>
+						<property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+					</sum>
+				</expression>
+				<scale>-1.0</scale>
+			</offset>
+		</input>
+		<input>
+			<condition>
+				<not><property>/autopilot/kap140/config/hsi-installed</property></not>
+			</condition>
+			<property>/autopilot/settings/heading-bug-latch</property>
+			<offset>
+				<property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+				<scale>-1.0</scale>
+			</offset>
+		</input>
+		<input>0</input>
+		<output>/autopilot/internal/heading-bug-latch-error</output>
+		<period>
+			<min>-180</min>
+			<max>180</max>
+		</period>
+	</filter>
+
+	<filter>
 		<name>Target Intercept Angle P</name>
 		<type>gain</type>
 		<gain>12.5</gain>

--- a/Models/Instruments/Avionics/kap140/kap140-proprules.xml
+++ b/Models/Instruments/Avionics/kap140/kap140-proprules.xml
@@ -1823,6 +1823,37 @@ We have captured the localizer and the GS.
                     <value>6</value>
                 </less-than>
                 <property>instrumentation/nav-source/signal-valid</property>
+                
+                <or>
+                    <!-- with DG+ROL mode: capture once the calculated intercept course is smaller than the commanded ROL course difference -->
+                    <and>
+                        <not><property alias="../../../../../../params/hsi-installed" /></not>
+                        <equals>
+                            <property>autopilot/kap140/settings/lateral-mode</property>
+                            <value>1</value>
+                        </equals>
+                        
+                        <greater-than-equals>
+                            <expression>
+                                <difference>
+                                    <abs><property>/autopilot/internal/heading-bug-latch-error</property></abs>
+                                    <abs><property>/autopilot/internal/intercept-angle</property></abs>
+                                </difference>
+                            </expression>
+                            <value>0</value>
+                        </greater-than-equals>
+                    </and>
+                    
+                    <!-- with HSI or DG+HDG: capture just using the radial course error -->
+                    <property alias="../../../../../../params/hsi-installed" />
+                    <and>
+                        <not-equals>
+                            <property>autopilot/kap140/settings/lateral-mode</property>
+                            <value>1</value>
+                        </not-equals>
+                    </and>
+                </or>
+                
                 <less-than>
                     <expression>
                         <abs><property>instrumentation/nav-source/heading-needle-deflection-norm</property></abs>

--- a/Models/Instruments/Avionics/kap140/kap140-proprules.xml
+++ b/Models/Instruments/Avionics/kap140/kap140-proprules.xml
@@ -1845,7 +1845,7 @@ We have captured the localizer and the GS.
                     </and>
                     
                     <!-- with HSI or DG+HDG: capture just using the radial course error -->
-                    <property alias="../../../../../../params/hsi-installed" />
+                    <property alias="../../../../../params/hsi-installed" />
                     <and>
                         <not-equals>
                             <property>autopilot/kap140/settings/lateral-mode</property>

--- a/gui/dialogs/kap140-dlg.xml
+++ b/gui/dialogs/kap140-dlg.xml
@@ -614,6 +614,8 @@
 						<property>autopilot/kap140/panel/state</property>
 						<value>4</value>
 					</greater-than>
+					<not><property>autopilot/kap140/roll-axis-fail</property></not>
+					<not><property>autopilot/kap140/pitch-axis-fail</property></not>
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/panel/state-old</property>
@@ -625,6 +627,8 @@
 						<property>autopilot/kap140/panel/state</property>
 						<value>4</value>
 					</greater-than>
+					<not><property>autopilot/kap140/roll-axis-fail</property></not>
+					<not><property>autopilot/kap140/pitch-axis-fail</property></not>
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/internal/target-climb-rate</property>
@@ -1196,10 +1200,10 @@
 						<property>autopilot/kap140/panel/state</property>
 						<value>6</value>
 					</equals>
-					<equal>
+					<equals>
 						<property>autopilot/kap140/settings/vertical-mode</property>
 						<value>1</value>
-					</equal>
+					</equals>
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/settings/vertical-mode</property>
@@ -1211,10 +1215,10 @@
 						<property>autopilot/kap140/panel/state</property>
 						<value>6</value>
 					</equals>
-					<less-than>
+					<equals>
 						<property>autopilot/kap140/settings/vertical-mode</property>
-						<value>0</value>
-					</less-than>
+						<value>-1</value>
+					</equals>
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/settings/vertical-mode</property>
@@ -1222,6 +1226,21 @@
 			</binding>
 			<binding>
 				<condition>
+					<equals>
+						<property>autopilot/kap140/panel/state</property>
+						<value>6</value>
+					</equals>
+				</condition>
+				<command>property-assign</command>
+				<property>autopilot/kap140/panel/gs-timer</property>
+				<value>0</value>
+			</binding>
+			<binding>
+				<condition>
+					<equals>
+						<property>autopilot/kap140/panel/state</property>
+						<value>6</value>
+					</equals>
 					<equals>
 						<property>autopilot/kap140/settings/vertical-mode</property>
 						<value>1</value>
@@ -1233,6 +1252,10 @@
 			</binding>
 			<binding>
 				<condition>
+					<equals>
+						<property>autopilot/kap140/panel/state</property>
+						<value>6</value>
+					</equals>
 					<equals>
 						<property>autopilot/kap140/settings/vertical-mode</property>
 						<value>2</value>
@@ -1368,10 +1391,10 @@
 						<property>autopilot/kap140/panel/state</property>
 						<value>6</value>
 					</equals>
-					<greater-than>
+					<equals>
 						<property>autopilot/kap140/settings/vertical-arm</property>
 						<value>0</value>
-					</greater-than>
+					</equals>
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/settings/vertical-arm</property>
@@ -1689,7 +1712,7 @@
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/settings/vertical-arm</property>
-				<value>1</value>
+				<value>2</value>
 			</binding>
 		</button>
 		<button>
@@ -1722,7 +1745,7 @@
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/settings/vertical-arm</property>
-				<value>1</value>
+				<value>2</value>
 			</binding>
 		</button>
 		<group>
@@ -1764,7 +1787,7 @@
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/settings/vertical-arm</property>
-				<value>1</value>
+				<value>2</value>
 			</binding>
 		</button>
 		<button>
@@ -1797,7 +1820,7 @@
 				</condition>
 				<command>property-assign</command>
 				<property>autopilot/kap140/settings/vertical-arm</property>
-				<value>1</value>
+				<value>2</value>
 			</binding>
 		</button>
 	</group>


### PR DESCRIPTION
The autopilot did try to fly 45-degree in the last capture step in ROL-mode even if a more steep/shallow angle was commanded.
For example, when commanding a 30-degree intercept angle and the needle went into the "capture-zone", the AP did capture and calculate an intercept-angle of 45-degree, resulting in an inward-turn which is then promply countered (left-right-wings-wiggle).
![grafik](https://user-images.githubusercontent.com/13608602/112869195-29d55e80-90bd-11eb-9933-cfeb67bdeb18.png)

----
A possible fix is to adjust the beam-capture filter so it does recognize ROL mode and arming of NAV/APR/REV; and in that cases only turn into the radial if the calculated capture-point for turning is reached (by comparing the intercept angles).
This is only done if no HSI is equipped. The intercept point calculation is briefly mentioned in the manual (no details on the code however); but all information for the implemented formula comes from the DG and localizer needle (so: "could be realistic").

Now the autopilot will not try to fly a steeper/shallower angle than was commanded by the ROL course until the calculated interception point is reached:

![kap140-newrol-intercept](https://user-images.githubusercontent.com/13608602/113636935-c2e31700-9673-11eb-9071-267b40778956.png)
![kap140-newrol-intercept-rev](https://user-images.githubusercontent.com/13608602/113636947-c9718e80-9673-11eb-9c2f-42f40ddcb12e.png)
(NAV/APR/REV tested with HDG and ROL intercept modes)

----
(this is a fix related to upstream https://github.com/reiszner/KAP140/issues/10)