### PR TITLE
More keybinds

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -125,8 +125,8 @@ A [quick introduction is in the FGFS-wiki](https://wiki.flightgear.org/Bendix/Ki
 
 - The AP can be activated by pressing and holding the "AP" key on the instrument. Note that the AP only activates after the automatic preflight checks are complete (`PFT n` in display). During these checks, various annunciators will illuminate. The AP will only engage after those are vanished.
 - After the PFT, you are prompted to enter a barometric pressure by a flashing `29.92` setting in the top right corner. The AP will not allow to be engaged until it is initialized.
-- The autopilot features a disconnect knob which is accessible by pressing `SHIFT-C`; the AP will disconnect and stay off.
-- Temporarily disconnect can be activated by pressing the `C` key. After release the AP will continue with its program.
+- The autopilot features a disconnect knob which is accessible by pressing `SHIFT-D`; the AP will disconnect and stay off.
+- Temporarily disconnect ("CWS") can be activated by pressing the `d` key. After release the AP will continue with its program.
 - Severe turbolences may trigger the over-g disconnect safety.
 
 

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -784,6 +784,23 @@ setlistener("/sim/model/hide-yoke", updateYokeTransparency, 1, 0);
 setlistener("/sim/model/hide-yoke-alpha-cmd", updateYokeTransparency, 1, 0);
 
 
+##########
+# FGComands for bindings
+##########
+var c182_cowlflap_step = func(v) {
+    var cowlflaps = props.globals.getNode("/controls/engines/engine/cowl-flaps-norm");
+    var next = cowlflaps.getValue() + v;
+    if (next > 1.0) next = 1.0;
+    if (next < 0.0) next = 0.0;
+    cowlflaps.setValue(next);
+}
+addcommand("c182_cowlflap_step_open", func {
+    c182_cowlflap_step(0.25);
+});
+addcommand("c182_cowlflap_step_close", func {
+    c182_cowlflap_step(-0.25);
+});
+
 
 ###########
 # INIT of Aircraft

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -149,6 +149,9 @@
   <state include="states/cruising-overlay.xml" n="4" />
   <state include="states/approach-overlay.xml" n="5" />
 
+  <virtual-cockpit>true</virtual-cockpit>
+  <allow-toggle-cockpit>true</allow-toggle-cockpit>
+
   <systems>
     <path>Aircraft/c182s/Systems/systems.xml</path>
     <autopilot n="0"> <!-- Must be before KAP140 -JD -->
@@ -751,11 +754,11 @@
    <line>  Takeoff ground roll: 795ft  over 50ft obstacle: 1,514ft</line>
    <line>  Landing ground roll: 590ft  over 50ft obstacle: 1,390ft</line>
    <key>
-    <name>c</name>
+    <name>d</name>
     <desc>KAP140 Autopilot CWS</desc>
    </key>
    <key>
-    <name>C</name>
+    <name>D</name>
     <desc>KAP140 Autopilot Disconnect</desc>
    </key>
    <key>
@@ -1509,32 +1512,32 @@
         </binding>
       </key>
 
-      <key n="99">
-        <name>c</name>
+      <key n="100">
+        <name>d</name>
         <desc>CWS Button KAP 140</desc>
-        <binding>
+        <binding n="20">
             <command>property-assign</command>
             <property>autopilot/kap140/settings/cws</property>
             <value>1</value>
         </binding>
         <mod-up>
-            <binding>
+            <binding n="20">
                 <command>property-assign</command>
                 <property>autopilot/kap140/settings/cws</property>
                 <value>0</value>
             </binding>
         </mod-up>
       </key>
-      <key n="67">
-        <name>C</name>
+      <key n="68">
+        <name>D</name>
         <desc>AP-DISC Button KAP 140</desc>
-        <binding>
+        <binding n="20">
             <command>property-assign</command>
             <property>autopilot/kap140/settings/ap-disc</property>
             <value>1</value>
         </binding>
         <mod-up>
-            <binding>
+            <binding n="20">
                 <command>property-assign</command>
                 <property>autopilot/kap140/settings/ap-disc</property>
                 <value>0</value>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -767,6 +767,10 @@
     <desc>Mixture rich/lean</desc>
    </key>
    <key>
+    <name>f/F</name>
+    <desc>Cowl flaps close/open</desc>
+   </key>
+   <key>
     <name>y/Y</name>
     <desc>Toggle yoke visibility</desc>
    </key>
@@ -1536,6 +1540,20 @@
                 <value>0</value>
             </binding>
         </mod-up>
+      </key>
+      <key n="102">
+        <name>f</name>
+        <desc>Cowl flaps close</desc>
+        <binding>
+            <command>c182_cowlflap_step_close</command>
+        </binding>
+      </key>
+      <key n="70">
+        <name>F</name>
+        <desc>Cowl flaps open</desc>
+        <binding>
+            <command>c182_cowlflap_step_open</command>
+        </binding>
       </key>
 
       <!-- overwriting { and } default aliases -->

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -135,6 +135,9 @@
   
   <checklists include="c182t-checklists.xml"/>
 
+  <virtual-cockpit>true</virtual-cockpit>
+  <allow-toggle-cockpit>true</allow-toggle-cockpit>
+
   <!-- Overlays (called with "state" command line option) -->
   <state include="states/auto-overlay.xml"     n="0" />
   <state include="states/saved-overlay.xml"    n="1" />

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -715,6 +715,10 @@
     <desc>Mixture rich/lean</desc>
    </key>
    <key>
+    <name>f/F</name>
+    <desc>Cowl flaps close/open</desc>
+   </key>
+   <key>
     <name>y/Y</name>
     <desc>Toggle yoke visibility</desc>
    </key>
@@ -1337,7 +1341,20 @@
           <property>sim/model/hide-yoke</property>
         </binding>
       </key>
-
+      <key n="102">
+        <name>f</name>
+        <desc>Cowl flaps close</desc>
+        <binding>
+            <command>c182_cowlflap_step_close</command>
+        </binding>
+      </key>
+      <key n="70">
+        <name>F</name>
+        <desc>Cowl flaps open</desc>
+        <binding>
+            <command>c182_cowlflap_step_open</command>
+        </binding>
+      </key>
 
       <!-- overwriting { and } default aliases -->
       <key n="123">


### PR DESCRIPTION
- Added `f`/`F` keybind to close/open cowl flaps
- Added default `c` keybind to show/hide cockpit
- Moved KAP-140 CWS keybind from `c` to `d` (and AP disconnect to `D` to stay consistent)


![grafik](https://user-images.githubusercontent.com/13608602/114158997-9ce49d80-9925-11eb-9a5c-66b5969ecd1f.png)
