### PR TITLE
HI offset knob tooltip shows relative offset now

### DIFF
--- a/Models/Instruments/hi.xml
+++ b/Models/Instruments/hi.xml
@@ -203,8 +203,13 @@
         <command>set-tooltip</command>
         <tooltip-id>heading-offset</tooltip-id>
         <label>Heading Offset: %3d</label>
-        <mapping>heading</mapping>
         <property>instrumentation/heading-indicator/offset-deg</property>
+        <mapping>nasal</mapping>
+        <script>
+            var r = arg[0];
+            if (r > 180) r = (360-r) *-1;
+            return r;
+        </script>
       </binding>
     </hovered>
    </animation>
@@ -422,8 +427,13 @@
         <command>set-tooltip</command>
         <tooltip-id>heading-offset</tooltip-id>
         <label>Heading Offset: %3d</label>
-        <mapping>heading</mapping>
         <property>instrumentation/heading-indicator/offset-deg</property>
+        <mapping>nasal</mapping>
+        <script>
+            var r = arg[0];
+            if (r > 180) r = (360-r) *-1;
+            return r;
+        </script>
       </binding>
     </hovered>
   </animation>
@@ -505,8 +515,13 @@
         <command>set-tooltip</command>
         <tooltip-id>heading-offset</tooltip-id>
         <label>Heading Offset: %3d</label>
-        <mapping>heading</mapping>
         <property>instrumentation/heading-indicator/offset-deg</property>
+        <mapping>nasal</mapping>
+        <script>
+            var r = arg[0];
+            if (r > 180) r = (360-r) *-1;
+            return r;
+        </script>
       </binding>
     </hovered>
   </animation>


### PR DESCRIPTION
The heading indicator offset tooltip showed the absolute offset, which yielded big numbers for slight offsets to the left. 
It would be more useful as a reference to show the offset relative from the instrument "zero-setting":

![grafik](https://user-images.githubusercontent.com/13608602/114685616-553d8780-9d12-11eb-96d2-b3eb5c8aeccc.png)
