### PR TITLE
Add Aerotow feature to C182S/T

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -130,6 +130,12 @@ A [quick introduction is in the FGFS-wiki](https://wiki.flightgear.org/Bendix/Ki
 - Severe turbolences may trigger the over-g disconnect safety.
 
 
+### Aerotowing gliders
+The C182S and C182T are equipped with an tow hook and can tow any JSBSim/YASIM glider compatible to FlightGears standard implementation.
+
+Once the glider pilot hooked into your Cessna, you can press `SHIFT-O` to release the hook. For connecting, get close infront of the glider. When accelerating, do it with caution, otherwise the rope my rip. Expect also other airplane behaviour when towing (longer takeoff roll, etc).
+
+
 FAQ
 ---
 Most of the [C172p's FAQ](http://wiki.flightgear.org/Cessna_172P#FAQ) also applies to the 182, so also read those.

--- a/Documentation.md
+++ b/Documentation.md
@@ -125,8 +125,8 @@ A [quick introduction is in the FGFS-wiki](https://wiki.flightgear.org/Bendix/Ki
 
 - The AP can be activated by pressing and holding the "AP" key on the instrument. Note that the AP only activates after the automatic preflight checks are complete (`PFT n` in display). During these checks, various annunciators will illuminate. The AP will only engage after those are vanished.
 - After the PFT, you are prompted to enter a barometric pressure by a flashing `29.92` setting in the top right corner. The AP will not allow to be engaged until it is initialized.
-- The autopilot features a disconnect knob which is accessible by pressing `SHIFT-C`; the AP will disconnect and stay off.
-- Temporarily disconnect can be activated by pressing the `C` key. After release the AP will continue with its program.
+- The autopilot features a disconnect knob which is accessible by pressing `SHIFT-D`; the AP will disconnect and stay off.
+- Temporarily disconnect ("CWS") can be activated by pressing the `d` key. After release the AP will continue with its program.
 - Severe turbolences may trigger the over-g disconnect safety.
 
 

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -784,6 +784,23 @@ setlistener("/sim/model/hide-yoke", updateYokeTransparency, 1, 0);
 setlistener("/sim/model/hide-yoke-alpha-cmd", updateYokeTransparency, 1, 0);
 
 
+##########
+# FGComands for bindings
+##########
+var c182_cowlflap_step = func(v) {
+    var cowlflaps = props.globals.getNode("/controls/engines/engine/cowl-flaps-norm");
+    var next = cowlflaps.getValue() + v;
+    if (next > 1.0) next = 1.0;
+    if (next < 0.0) next = 0.0;
+    cowlflaps.setValue(next);
+}
+addcommand("c182_cowlflap_step_open", func {
+    c182_cowlflap_step(0.25);
+});
+addcommand("c182_cowlflap_step_close", func {
+    c182_cowlflap_step(-0.25);
+});
+
 
 ###########
 # INIT of Aircraft

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -149,6 +149,9 @@
   <state include="states/cruising-overlay.xml" n="4" />
   <state include="states/approach-overlay.xml" n="5" />
 
+  <virtual-cockpit>true</virtual-cockpit>
+  <allow-toggle-cockpit>true</allow-toggle-cockpit>
+
   <systems>
     <path>Aircraft/c182s/Systems/systems.xml</path>
     <autopilot n="0"> <!-- Must be before KAP140 -JD -->
@@ -751,11 +754,11 @@
    <line>  Takeoff ground roll: 795ft  over 50ft obstacle: 1,514ft</line>
    <line>  Landing ground roll: 590ft  over 50ft obstacle: 1,390ft</line>
    <key>
-    <name>c</name>
+    <name>d</name>
     <desc>KAP140 Autopilot CWS</desc>
    </key>
    <key>
-    <name>C</name>
+    <name>D</name>
     <desc>KAP140 Autopilot Disconnect</desc>
    </key>
    <key>
@@ -1509,32 +1512,32 @@
         </binding>
       </key>
 
-      <key n="99">
-        <name>c</name>
+      <key n="100">
+        <name>d</name>
         <desc>CWS Button KAP 140</desc>
-        <binding>
+        <binding n="20">
             <command>property-assign</command>
             <property>autopilot/kap140/settings/cws</property>
             <value>1</value>
         </binding>
         <mod-up>
-            <binding>
+            <binding n="20">
                 <command>property-assign</command>
                 <property>autopilot/kap140/settings/cws</property>
                 <value>0</value>
             </binding>
         </mod-up>
       </key>
-      <key n="67">
-        <name>C</name>
+      <key n="68">
+        <name>D</name>
         <desc>AP-DISC Button KAP 140</desc>
-        <binding>
+        <binding n="20">
             <command>property-assign</command>
             <property>autopilot/kap140/settings/ap-disc</property>
             <value>1</value>
         </binding>
         <mod-up>
-            <binding>
+            <binding n="20">
                 <command>property-assign</command>
                 <property>autopilot/kap140/settings/ap-disc</property>
                 <value>0</value>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -152,6 +152,20 @@
   <virtual-cockpit>true</virtual-cockpit>
   <allow-toggle-cockpit>true</allow-toggle-cockpit>
 
+  <hitches>
+    <aerotow>
+        <force_name_jsbsim type="string">hitch</force_name_jsbsim>
+        <force-is-calculated-by-other type="bool">true</force-is-calculated-by-other>
+        <mp-auto-connect-period type="float">1.0</mp-auto-connect-period>
+        <!-- OPTIONAL
+            <decoupled-force-and-rope-locations type="bool">true</decoupled-force-and-rope-locations>
+            <local-pos-x type="float">1.5</local-pos-x>
+            <local-pos-y type="float"> 0.00</local-pos-y>
+            <local-pos-z type="float">-0.3</local-pos-z>
+        -->
+    </aerotow>
+  </hitches>
+
   <systems>
     <path>Aircraft/c182s/Systems/systems.xml</path>
     <autopilot n="0"> <!-- Must be before KAP140 -JD -->
@@ -780,6 +794,10 @@
    <key>
     <name>s</name>
     <desc>Engine Starter</desc>
+   </key>
+   <key>
+       <name>O</name>
+       <desc>Open aerotow-hook</desc>
    </key>
   </help>
 
@@ -1492,7 +1510,14 @@
  <input>
     <keyboard>
 
-
+      <key n="79">
+        <name>O</name>
+        <desc>Open aerotow-hook</desc>
+        <binding>
+          <command>nasal</command>
+          <script>towing.releaseHitch("aerotow")</script>
+        </binding>
+      </key>
       <key n="121">
         <name>y</name>
         <desc>Toggle yoke visibility.</desc>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -767,6 +767,10 @@
     <desc>Mixture rich/lean</desc>
    </key>
    <key>
+    <name>f/F</name>
+    <desc>Cowl flaps close/open</desc>
+   </key>
+   <key>
     <name>y/Y</name>
     <desc>Toggle yoke visibility</desc>
    </key>
@@ -1536,6 +1540,20 @@
                 <value>0</value>
             </binding>
         </mod-up>
+      </key>
+      <key n="102">
+        <name>f</name>
+        <desc>Cowl flaps close</desc>
+        <binding>
+            <command>c182_cowlflap_step_close</command>
+        </binding>
+      </key>
+      <key n="70">
+        <name>F</name>
+        <desc>Cowl flaps open</desc>
+        <binding>
+            <command>c182_cowlflap_step_open</command>
+        </binding>
       </key>
 
       <!-- overwriting { and } default aliases -->

--- a/c182s.xml
+++ b/c182s.xml
@@ -2109,6 +2109,18 @@
                 <z>1.0</z>
             </direction>
         </force>
+        <force name="hitch" frame="BODY" unit="LBS" >
+            <location unit="M">
+                <x> 5.601</x>
+                <y> 0.0000</y>
+                <z>0.115</z>
+            </location>
+            <direction>
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+            </direction>
+        </force>
     </external_reactions>
     
     <system file="c182s-stallhorn"/>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -135,6 +135,9 @@
   
   <checklists include="c182t-checklists.xml"/>
 
+  <virtual-cockpit>true</virtual-cockpit>
+  <allow-toggle-cockpit>true</allow-toggle-cockpit>
+
   <!-- Overlays (called with "state" command line option) -->
   <state include="states/auto-overlay.xml"     n="0" />
   <state include="states/saved-overlay.xml"    n="1" />

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -146,6 +146,20 @@
   <state include="states/cruising-overlay.xml" n="4" />
   <state include="states/approach-overlay.xml" n="5" />
 
+  <hitches>
+    <aerotow>
+        <force_name_jsbsim type="string">hitch</force_name_jsbsim>
+        <force-is-calculated-by-other type="bool">true</force-is-calculated-by-other>
+        <mp-auto-connect-period type="float">1.0</mp-auto-connect-period>
+        <!-- OPTIONAL
+            <decoupled-force-and-rope-locations type="bool">true</decoupled-force-and-rope-locations>
+            <local-pos-x type="float">1.5</local-pos-x>
+            <local-pos-y type="float"> 0.00</local-pos-y>
+            <local-pos-z type="float">-0.3</local-pos-z>
+        -->
+    </aerotow>
+  </hitches>
+
   <systems>
     <path>Aircraft/c182s/Systems/systems.xml</path>
     <autopilot>
@@ -728,6 +742,10 @@
    <key>
     <name>s</name>
     <desc>Engine Starter</desc>
+   </key>
+   <key>
+       <name>O</name>
+       <desc>Open aerotow-hook</desc>
    </key>
    <key>
     <name>:p</name>
@@ -1325,7 +1343,14 @@
  <input>
     <keyboard>
       <multikey include="Aircraft/Instruments-3d/FG1000/fg1000-multikey.xml"/>
-
+      <key n="79">
+        <name>O</name>
+        <desc>Open aerotow-hook</desc>
+        <binding>
+          <command>nasal</command>
+          <script>towing.releaseHitch("aerotow")</script>
+        </binding>
+      </key>
       <key n="121">
         <name>y</name>
         <desc>Toggle yoke visibility.</desc>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -715,6 +715,10 @@
     <desc>Mixture rich/lean</desc>
    </key>
    <key>
+    <name>f/F</name>
+    <desc>Cowl flaps close/open</desc>
+   </key>
+   <key>
     <name>y/Y</name>
     <desc>Toggle yoke visibility</desc>
    </key>
@@ -1337,7 +1341,20 @@
           <property>sim/model/hide-yoke</property>
         </binding>
       </key>
-
+      <key n="102">
+        <name>f</name>
+        <desc>Cowl flaps close</desc>
+        <binding>
+            <command>c182_cowlflap_step_close</command>
+        </binding>
+      </key>
+      <key n="70">
+        <name>F</name>
+        <desc>Cowl flaps open</desc>
+        <binding>
+            <command>c182_cowlflap_step_open</command>
+        </binding>
+      </key>
 
       <!-- overwriting { and } default aliases -->
       <key n="123">

--- a/c182t.xml
+++ b/c182t.xml
@@ -2109,6 +2109,18 @@
                 <z>1.0</z>
             </direction>
         </force>
+        <force name="hitch" frame="BODY" unit="LBS" >
+            <location unit="M">
+                <x> 5.601</x>
+                <y> 0.0000</y>
+                <z>0.115</z>
+            </location>
+            <direction>
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+            </direction>
+        </force>
     </external_reactions>
     
     <system file="c182s-stallhorn"/>


### PR DESCRIPTION
This adds compatibility to FlightGears default aerotow feature: https://wiki.flightgear.org/Howto:Do_aerotow_over_the_net
Once the glider pilot attached the rope, the Cessna pilot can release the hook anytime by pressing `SHIFT-O`.

- [ ] Once merged, we should add the feature to the FGFS Wiki:
  - [ ] At the [c182 aircraft entry](https://wiki.flightgear.org/Cessna_182S) add a section for the towing [like the Piper_J3_Cub](https://wiki.flightgear.org/Piper_J3_Cub#Aerotowing) already has
  - [ ] At the [aircraft info template](https://wiki.flightgear.org/w/index.php?title=Cessna_182S/info&action=edit), add the Type `aircraft/Glider tug`
  - [ ] At the [aerotow wiki page](https://wiki.flightgear.org/Howto:Do_aerotow_over_the_net) add the craft as compatible


----
Tested :ok: with the ASK21 :smile::
![Screenshot_20210426_134326](https://user-images.githubusercontent.com/13608602/116078506-fd4e3b80-a696-11eb-8ec9-ac2324c5f3e5.jpg)

----
Close #405 