### PR TITLE
Implement Spark plug fouling

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -44,8 +44,17 @@ Otherwise you need to pay attention to varios engine related things:
   the oil pump will not be able to supply enough pressure for good lubrication, leading to engine failure. Also monitor the oil service time as
   old oil does not perform so well (cycle it about every 50 hrs).
   Also some effects like additional friction with too hot oil and cold-start will be simulated.
-- `Allow Spark plug icing`  
-  If active, the spark plugs can freeze over, preventing engine start. This can occur in cold weather if the engine starts and quits shortly after, because then the engine is still cold, letting the water produced by the combustion process condensate on the plugs where they freeze over. This will prevent furter engine starts. To prevent this, preheat the engine properly, and if it happened, heat the engine so the ice melts (which can take considerable time!)
+- `Allow Spark plug icing/fouling`  
+  If active, the spark plugs can freeze over, preventing engine start. This can occur in cold weather if the engine starts and quits shortly after,
+  because then the engine is still cold, letting the water produced by the combustion process condensate on the plugs where they freeze over. This
+  will prevent furter engine starts. To prevent this, preheat the engine properly, and if it happened, heat the engine so the ice melts (which can
+  take considerable time!)  
+  Also, if the combustion temperature is too low and/or or the mixture too rich, the spark plugs can slowly foul with lead and carbon deposits,
+  eventually shortening the electrical spark. Be sure to keep the engine (CHT) warm enough by proper leaning and run-up procedures. In short, keep
+  the combustion temperature above about 264°C/507°F and avoid idling too long at <1000 RPM. Also, lean to peak EGT on ground/taxi and warm-up the
+  engine at 1200 RPM. Should a magneto check reveal spark plug problems, its most of the time some fouled plugs. Put the engine to 1800 RPM and 50°
+  lean of peak EGT. Let it run for about 30 seconds, monitor CHT. This should clean the deposits which a second magneto check should verify.  
+When parking the plane after flight, you should go to 1800 RPM and lean mix for 20 secs, then reduce throttle to 1000 RPM and then stop the engine by pulling mixture to the cut-off position.
 - `Winter Kit`  
   The winter kit is needed in cold weather (<20°F/-6°C) to reduce cooling air flow. If not supplied, the engine will possibly not get warm enough to develop good power, but be sure to remove it in hot weather, otherwise you risk too high CHT temps.
 
@@ -117,6 +126,8 @@ The pitot tube and stall horn can ice too, so you might not get any warning of a
 Some properties can be set at runtime to adjust the simulators state. You may use this for example in a script or trough a telnet session.  
 Additionally to the default ones, the c182 knows the following:
 - `/fdm/jsbsim/systems/propulsion/manual-friction` (in horsepowers) to induce additional engine friction, which reduces power.
+- `/engines/engine/manual-roughness-factor` (`0.0` to `1.0`) to induce engine roughness
+- `/engines/engine/manual-power-reduction-pct` (`0.0` to `1.0`) to make the engine less efficient
 - `/engines/engine/kill-engine` immediately kills the engine if set to `1`.
 
 ### KAP 140 Autopilot
@@ -179,7 +190,10 @@ Most of the [C172p's FAQ](http://wiki.flightgear.org/Cessna_172P#FAQ) also appli
 4. Why does the Autostart fail to start the engine?  
    This should never happen. Please file a bug report at the github project site.
 5. Why does the engine die immediately after startup?  
-   Most probably the engine is too cold and you advanced the throttle too fast. Warm the engine at about 1000rpm for some more time. Other sources may
-   be contaminated fuel or a damaged engine.
+   Most probably the engine is too cold and you advanced the throttle too fast. Warm the engine at about 1200rpm for some more time. Other sources may
+   be contaminated fuel, a damaged engine or fouled spark plugs.
 6. The glareshield, pedestal and interior lights are not working. Is there a bug?
    Most probably you just need to enable ALS and move the model shader slider to the right (check extended settings!) in your graphic settings.
+7. Engine power is not so good, especially on one magneto. What should I do?  
+   Most probably you experience spark plug fouling. You let the engine get too cold by not leaning properly or excessive engine cooling. Better observe your mixture leaning, power and cowl flaps setting. On ground, don't let the plane idle on full rich, but set RPM to 1200 and lean to peak EGT. For Taxiing, reduce power unless paying extra for brakes is no issue :).  
+   To remove the deposits on the spark plugs: put the engine to 1800 rpm and lean to peak EGT; let it run for about half a minute and repeat the mag check; repeat procedure if needed.

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -78,6 +78,14 @@ var engine_coughing = func(){
         delay = 3.0 * rand() + 17 - 41.25 * total_water_contamination;
     };
     
+    
+    # if coughing from rough engine operation, it depends on severity;
+    var roughness_factor = getprop("/engines/engine/roughness-factor") or 0;
+    if (roughness_factor > 0.8) delay = (roughness_factor*10 - 8) + (-0.25 + rand()*0.5);
+    
+    
+    # Schedule next cough check
+    if (delay < 0.2) delay = 0.2;
     coughing_timer.restart(delay);
     
 }
@@ -301,6 +309,22 @@ var applySparkPlugicing = func() {
     }
 }
 
+
+# ======== Spark plug fouling simulation =========
+# We just need a random number to randomize the affected magnetos a bit.
+# This way its not always the same magneto/plugs fouling.
+var spark_plug_fouling_affected = rand();
+if (spark_plug_fouling_affected <= 0.40) {
+    setprop("/fdm/jsbsim/systems/propulsion/sparkplugs/left/affected",  1 );
+    setprop("/fdm/jsbsim/systems/propulsion/sparkplugs/right/affected", 0 );
+} else if (spark_plug_fouling_affected <= 0.80) {
+    setprop("/fdm/jsbsim/systems/propulsion/sparkplugs/left/affected",  0);
+    setprop("/fdm/jsbsim/systems/propulsion/sparkplugs/right/affected", 1);
+} else {
+    # If both are affected make their rates a little different
+    setprop("/fdm/jsbsim/systems/propulsion/sparkplugs/left/affected",  1 + (-0.5 + rand())*0.20 );
+    setprop("/fdm/jsbsim/systems/propulsion/sparkplugs/right/affected", 1 + (-0.5 + rand())*0.20 );
+}
 
 
 # ======= OIL Pump handling =====

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -51,6 +51,180 @@
         </output>
     </logic>
     
+    
+    <!-- ============================================================== -->
+    <!-- Engine roughness                                               -->
+    <!-- ============================================================== -->
+    <!-- A rough running engine will oscillate RPM and very rough engine will also sputter -->
+    
+    <!-- Combustion out of place -->
+    <filter>
+        <name>Engine roughness due to combustion nearly out of range</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <product>
+                    <property>/engines/engine/complex-engine-procedures</property>
+                    <table>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <entry><ind>7.9</ind><dep>1.0</dep></entry>
+                        <entry><ind>9.0</ind><dep>0.0</dep></entry>
+                        <entry><ind>17.0</ind><dep>0.0</dep></entry>
+                        <entry><ind>18.9</ind><dep>1.0</dep></entry>
+                    </table>
+                </product>
+            </expression>
+        </input>
+        <output>
+            <property>/engines/engine/combustion-roughness-factor</property>
+        </output>
+    </filter>
+    
+    <!-- Open Throttle with oil still cold -->
+    <filter>
+        <name>Engine roughness due to Open Throttle with oil still cold</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <product>
+                    <property>/engines/engine/complex-engine-procedures</property>
+                    <property>/engines/engine/allow-oil-management</property>
+                    <table>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <entry><ind>0.40</ind><dep>0.0</dep></entry>
+                        <entry><ind>1.00</ind><dep>1.5</dep></entry>
+                    </table>
+                    <table>
+                        <property>/engines/engine/oil-final-temperature-degf</property>
+                        <entry><ind>50.0</ind><dep>1.0</dep></entry>
+                        <entry><ind>65.0</ind><dep>0.0</dep></entry>
+                    </table>
+                </product>
+            </expression>
+        </input>
+        <output>
+            <property>/engines/engine/cold-oil-roughness-factor</property>
+        </output>
+    </filter>
+    
+    <!-- Engine running rough with one magneto failed and too lean (POH 3-20) -->
+    <!-- NOTE: This is not the same as signle magneto operation, where only one mag fires. Here, one mag is just bad/failed, causing misfires/mistimings -->
+    <filter>
+        <name>Engine roughness due to single magneto failure</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <product>
+                    <!-- both mags selected -->
+                    <property>/fdm/jsbsim/systems/propulsion/sparkplugs/left/magneto-selected</property>
+                    <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/magneto-selected</property>
+                    
+                    <!-- one is not serviceable -->
+                    <difference>
+                        <value>1</value>
+                        <product>
+                            <property>/controls/engines/engine/faults/left-magneto-serviceable</property>
+                            <property>/controls/engines/engine/faults/right-magneto-serviceable</property>
+                        </product>
+                    </difference>
+                    
+                    <sum>
+                        <!-- rough when too lean -->
+                        <table>
+                            <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                            <entry><ind>12.5</ind><dep>0.025</dep></entry>
+                            <entry><ind>15.0</ind><dep>0.10</dep></entry>
+                        </table>
+                        
+                        <!-- rough when power setting not good -->
+                        <table>
+                            <property>/engines/engine/rpm</property>
+                            <entry><ind>1900</ind><dep>0.025</dep></entry>
+                            <entry><ind>2200</ind><dep>0.10</dep></entry>
+                            <entry><ind>2400</ind><dep>0.05</dep></entry>
+                        </table>
+                    </sum>
+                </product>
+            </expression>
+        </input>
+        <output>
+            <property>/engines/engine/mag-singlefail-bothselected-roughness-factor</property>
+        </output>
+    </filter>
+    
+    <!-- Final roughness is the sum of all roughness sources -->
+    <filter>
+        <name>Engine roughness factor</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <!-- only with running engine and enabled simulation -->
+                <and>
+                    <property>/engines/engine/running</property>
+                    <property>/engines/engine/complex-engine-procedures</property>
+                </and>
+            </condition>
+            <expression>
+                <sum>
+                    <property>/engines/engine/manual-roughness-factor</property> <!-- for fun with telnet :) -->
+                    <property>/engines/engine/cold-oil-roughness-factor</property>
+                    <property>/engines/engine/combustion-roughness-factor</property>
+                    <property>/engines/engine/mag-singlefail-bothselected-roughness-factor</property>
+                    <property>/fdm/jsbsim/systems/propulsion/sparkplugs/fouling-roughness-factor</property>
+                </sum>
+            </expression>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/engines/engine/roughness-factor</property>
+        </output>
+        <min>0.0</min>
+        <max>1.0</max>
+    </filter>
+    
+    <!-- Generate roughness RPM oscillation effect -->
+    <filter>
+        <name>Engine roughness rpm oscillation trigger</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <mod>
+                    <floor>
+                        <product>
+                            <property>/sim/time/elapsed-sec</property>
+                            <value>2</value>
+                        </product>
+                    </floor>
+                    <value>2</value>
+                </mod>
+            </expression>
+        </input>
+        <output>/engines/engine/roughness-rpm-oscillation-trigger</output>
+        <min>0</min>
+        <max>1</max>
+    </filter>
+    <filter>
+        <name>Engine roughness rpm oscillation ammount</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <product>
+                    <property>/engines/engine/roughness-rpm-oscillation-trigger</property>
+                    <table>
+                        <property>/engines/engine/roughness-factor</property>
+                        <entry><ind>0</ind><dep>0.0</dep></entry>
+                        <entry><ind>1</ind><dep>0.5</dep></entry>
+                    </table>
+                </product>
+            </expression>
+        </input>
+        <output>/engines/engine/roughness-rpm-reduction-pct</output>
+        <min>0.0</min>
+        <max>1.0</max>
+    </filter>
+    
 
     <!-- ============================================================== -->
     <!-- Fuel contamination and low oil level                           -->
@@ -282,20 +456,14 @@
                     <property>/fdm/jsbsim/systems/propulsion/friction-critical</property>
                 </and>
                 
-                <!-- Engine is coughing if still cold and throttle is wide open -->
+                <!-- Engine is coughing if it runs really rough -->
                 <and>
-                    <property>/engines/engine/complex-engine-procedures</property>
-                    <property>/engines/engine/allow-oil-management</property>
-                    <not><property>/sim/start-state-internal/oil-temp-override</property></not>
                     <greater-than>
-                        <property>/controls/engines/engine[0]/throttle</property>
-                        <value>0.65</value>
+                        <property>/engines/engine/roughness-factor</property>
+                        <value>0.80</value>
                     </greater-than>
-                    <less-than>
-                        <property>/engines/engine/oil-final-temperature-degf</property>
-                        <value>65</value>
-                    </less-than>
                 </and>
+                
                 
                 <!-- Engine is coughing shortly before it starves of fuel -->
                 <and>

--- a/Systems/propulsion.xml
+++ b/Systems/propulsion.xml
@@ -9,8 +9,7 @@
 
     
     <channel name="engine power">
-  	
-<fcs_function name="systems/engine/MP-alt-volumetric-efficiency-curve">
+        <fcs_function name="systems/engine/MP-alt-volumetric-efficiency-curve">
           <function>
                 <table>
                     <independentVar lookup="row">atmosphere/density-altitude</independentVar>
@@ -26,7 +25,7 @@
 		12000 0.22 0.82 0.83 0.835 0.85 0.79 0.79  0.79 0.79 0.89 0.89 0.89	0.89  0.89 0.89 0.89 
 		14000 0.25 0.84 0.835 0.84 0.77 0.77 0.77 0.77 0.87 0.87 0.87 0.87 0.87  0.87 0.87 0.87 
                    </tableData> 
-                </table>  
+                </table>
           </function>
           <output>propulsion/engine/volumetric-efficiency</output>   
         </fcs_function>
@@ -35,8 +34,8 @@
 	
 
 
-<!-- Power based on fuel flow-->
-<fcs_function name="systems/engine/MP-alt-bsfc-lbs_hphr-curve">
+        <!-- Power based on fuel flow-->
+        <fcs_function name="systems/engine/MP-alt-bsfc-lbs_hphr-curve">
           <function>
             <table>
                 <independentVar lookup="row">atmosphere/density-altitude</independentVar>
@@ -61,7 +60,7 @@
           <output>propulsion/engine/bsfc-lbs_hphr</output>   
         </fcs_function>
 	
- <fcs_function name="systems/engine/RAM-Air-Factor">
+        <fcs_function name="systems/engine/RAM-Air-Factor">
           <function>
                 <table>
                     <independentVar lookup="row">atmosphere/density-altitude</independentVar>
@@ -85,22 +84,53 @@
           <output>propulsion/engine/ram-air-factor</output>   
         </fcs_function>
 	
-	
-<!--<fcs_function name="systems/engine/Air-Intake-Impedance-Factor">
-          <function>
-                <table>
-                    <independentVar lookup="row">atmosphere/density-altitude</independentVar>
-                    <tableData breakPoint="0">
-                        0		0.2		
-		5000		0.2		
-		14000	-0.0	
-                   </tableData>
-                </table>  
-          </function>
-          <output>propulsion/engine/air-intake-impedance-factor</output>   
+        
+        
+        <!-- Hooks for dynamic power reduction -->
+        <summer name="systems/engine/power-reduction-pct">
+            <input>/engines/engine/manual-power-reduction-pct</input>   <!-- for fun with telnet, etc -->
+            <input>/engines/engine/roughness-rpm-reduction-pct</input>  <!-- see engine.xml -->
+            
+            <output>systems/engine/power-reduction-pct</output>
+            <clipto>
+                <min> 0.0 </min>
+                <max> 1.0 </max>
+            </clipto>
+        </summer>
+        
+        
+        <!-- Air impedance is fixed at 0.18; but adjusted for effects.
+            Power reduction is with a quick response implemented here,
+            however this is hacky as it is mixture dependent and MP pressure follows too.
+        -->
+        <!-- original base value from engIO540AB1A5.xml-->
+        <!--<fcs_function name="systems/engine/Air-Intake-Impedance-Factor">
+            <function>
+                <sum>
+                    <value>0.18</value>
+                    
+                    <table>
+                        <independentVar lookup="row">systems/engine/power-reduction-pct</independentVar>
+                        <tableData>
+                            0.00   0.00
+                            0.10   0.35
+                            0.20   0.55
+                            0.30   1.54
+                            0.40   2.03
+                            0.50   2.70
+                            0.60   3.65
+                            0.70   4.70
+                            0.80   5.55
+                            0.90   7.30
+                            1.00  15.00
+                        </tableData>
+                    </table>
+                </sum>
+            </function>
+            <output>propulsion/engine/air-intake-impedance-factor</output>   
         </fcs_function>-->
 	
-       </channel>
+    </channel>
 
 <channel name= "Prop Icing">
 <fcs_function name="systems/propulsion/prop-ice">
@@ -140,23 +170,445 @@
  </channel>
  
 
-<channel name="sparkPlugs">
-    <!-- Calculates an approximated spark plug temperature -->
-    <!-- this is currently not really close, but we need it just for the spark plug icing for now.
-        the reasoning is: CHT is directly exposed to the combustion, thus heats very quickly.
-        We need however the temperature at the spark plug, which gets cooled indicrectly from the oil and
-        engine block, thus reacts slower to temperature changes (but quicker than the oil).
+<channel name="sparkPlugs" execrate="8">
+    <!-- Calculates an approximated spark plug temperature.
+         NOTE: this is currently not based on real data but a guess.
+         EGT is a proxy for the combustion temperature. At stochiometric mixture (AFR 13.9) it is about 1560°F, maxPWR~1400°F.
+         We however add a bit temperature boost ~50°F LoP because of better combustion, afterwards the cooling effect of excessive air overtakes.
     -->
-    <fcs_function name="/engines/engine/sparkplugs-temperature-degf">
-        <description>Simulates Spark plug temperature</description>
+    <fcs_function name="systems/propulsion/sparkplugs/temperature-degf-tgt">
+        <description>Simulates combustion temperature</description>
         <function>
-            <quotient>
-                <sum>
+            <sum>
+                <product>
+                    <property>/engines/engine/running</property>
+                    
+                    <property>/engines/engine/egt-degf</property>
+                    <table>
+                        <independentVar>propulsion/engine/engine-rpm</independentVar>
+                        <tableData>
+                             800   0.20
+                            1000   0.35
+                            2400   0.60
+                        </tableData>
+                    </table>
+                    <table>
+                        <independentVar>propulsion/engine/AFR</independentVar>
+                        <tableData>
+                             13.90  1.0
+                             14.45  1.12
+                             15.50  1.0
+                        </tableData>
+                    </table>
+                </product>
+                
+                <product>
+                    <not><property>/engines/engine/running</property></not>
                     <property>/engines/engine/oil-final-temperature-degf</property>
-                    <property>/engines/engine/cht-compensated-temperature-degf</property>
+                </product>
+            </sum>
+        </function>
+    </fcs_function>
+    <fcs_function name="/fdm/jsbsim/systems/propulsion/sparkplugs/temperature-degf-tgt-ratelimit">
+        <!-- damping the initial heating at the start to give the icing implementation a chance to catch on -->
+        <function>
+            <table>
+                <independentVar>/engines/engine/sparkplugs-temperature-degf</independentVar>
+                <tableData>
+                    32   2.00
+                    100  20.00
+                    200  50.00
+                </tableData>
+            </table>
+        </function>
+    </fcs_function>
+    <actuator name="/engines/engine/sparkplugs-temperature-degf">
+        <input> /fdm/jsbsim/systems/propulsion/sparkplugs/temperature-degf-tgt </input>
+        <rate_limit> /fdm/jsbsim/systems/propulsion/sparkplugs/temperature-degf-tgt-ratelimit </rate_limit>
+    </actuator>
+    
+    
+    <!-- Booleans to see which magneto is selected -->
+    <switch name="systems/propulsion/sparkplugs/right/magneto-selected">
+        <default value="0"/>
+        <test logic="OR" value="1">
+            /controls/switches/magnetos EQ 1
+            /controls/switches/magnetos EQ 3
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/left/magneto-selected">
+        <default value="0"/>
+        <test logic="OR" value="1">
+            /controls/switches/magnetos EQ 2
+            /controls/switches/magnetos EQ 3
+        </test>
+    </switch>
+    
+    <!-- Left Spark plug fouling -->
+    <!-- The following switches calculate the fouling conditions -->
+    <switch name="systems/propulsion/sparkplugs/left/carbon-fouling">
+        <!-- Carbon fouling occurs with overly rich mixture.
+             AFR:  8=no combustion; <8.15 severe RPM loss; <12=rich; ~12.0 is MaxPWR; 13.9 is Peak ~EGT; > 13.9=LoP; ~18.9 engine cutoff-->
+        <default value="0"/>
+        <test logic="AND" value="1">
+            /engines/engine/running  EQ 1
+            propulsion/engine/AFR    LT 11.0
+        </test>
+        <test logic="AND" value="-1">
+            /engines/engine/running    EQ 1
+            propulsion/engine/AFR GT   11.5
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/left/lead-fouling">
+        <!-- Lead fouling occurs when the combustion temperature is not hot enough to activate
+             the EDB lead scavenge agent (temps < 264°C/507.2°F). -->
+        <default value="0"/>
+        <test logic="AND" value="1">
+            /engines/engine/running                     EQ 1
+            /engines/engine/sparkplugs-temperature-degf LT 507.2 
+        </test>
+        <test logic="AND" value="-1">
+            /engines/engine/running                     EQ 1
+            /engines/engine/sparkplugs-temperature-degf GT 507.2
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/left/disabled-fouling">
+        <!-- The plug is not running but supplied with fuel. This will slowly foul (running on one magneto). -->
+        <!-- It will be removed if the plug is firing again in "cleaning" conditions. -->
+        <default value="0"/>
+        <test logic="AND" value="1">
+            <test logic="OR">
+                /engines/engine/running           EQ 1
+                /engines/engine/cranking          EQ 1
+            </test>
+            systems/propulsion/sparkplugs/left/magneto-selected EQ 0
+        </test>
+    </switch>
+    
+    <!-- This switch calculates the final decision if we should clean/foul the plugs -->
+    <switch name="systems/propulsion/sparkplugs/left/fouling-change">
+        <default value="0"/>
+        <test logic="AND" value="0">
+            <!-- Do not change the value if simulation is not activated -->
+            /engines/engine/allow-sparkplug-icing EQ 0
+        </test>
+        <test logic="OR" value="1">
+            systems/propulsion/sparkplugs/left/carbon-fouling   GT 0
+            systems/propulsion/sparkplugs/left/lead-fouling     GT 0
+            systems/propulsion/sparkplugs/left/disabled-fouling GT 0
+        </test>
+        <test logic="AND" value="-1">
+            systems/propulsion/sparkplugs/left/carbon-fouling LT 0
+            systems/propulsion/sparkplugs/left/lead-fouling   LE 0
+        </test>
+        <test logic="AND" value="-1">
+            systems/propulsion/sparkplugs/left/carbon-fouling LE 0
+            systems/propulsion/sparkplugs/left/lead-fouling   LT 0
+        </test>
+    </switch>
+    
+    <!-- Calculate decrease/stable/increase of plugs foul state
+         (the switch has three states: 0=stable; -1/+1=clean/foul;
+          and the increase/decrease rate is dynamic. Finally, the
+          actuator represents the current fouling-state in percent -->
+    <switch name="systems/propulsion/sparkplugs/left/fouling-tgt">
+        <default value="systems/propulsion/sparkplugs/left/fouling-norm"/>
+        <test logic="AND" value="0.0">
+            /fdm/jsbsim/damage/repairing EQ 1
+        </test>
+        <test logic="AND" value="systems/propulsion/sparkplugs/left/fouling-savedrestore">
+            /sim/time/elapsed-sec        LT 0.1
+        </test>
+        <test logic="AND" value="1.0"> <!-- Flooded engine makes plugs wet/fouled -->
+            /engines/engine/running      EQ 0
+            /systems/fuel/engine-flooded EQ 1
+        </test>
+        <test logic="AND" value="1.0">
+            /engines/engine/running EQ 1
+            systems/propulsion/sparkplugs/left/fouling-change GT 0
+        </test>
+        <test logic="AND" value="0.0">
+            /engines/engine/running EQ 1
+            systems/propulsion/sparkplugs/left/fouling-change LT 0
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/left/fouling-norm-ratelimit-swtch">
+        <default value="0"/>
+        <test logic="OR" value="999"> <!-- insta repair/restore -->
+            /fdm/jsbsim/damage/repairing EQ 1
+            /sim/time/elapsed-sec        LT 0.1
+        </test>
+        <test logic="AND" value="0.50"> <!-- Flooded engine makes plugs fouled -->
+            /engines/engine/running      EQ 0
+            /systems/fuel/engine-flooded EQ 1
+        </test>
+        <test logic="AND" value="0.00166"> <!-- ~10min=600s to fully develop -->
+            systems/propulsion/sparkplugs/left/fouling-change GT 0
+        </test>
+        <test logic="AND" value="0.0005"> <!-- long to fully remedy with just above temps and lead fouling -->
+            systems/propulsion/sparkplugs/temperature-degf-tgt LT 730.0
+            systems/propulsion/sparkplugs/left/fouling-change  LT 0
+            systems/propulsion/sparkplugs/left/lead-fouling    LE 0
+        </test>
+        <test logic="AND" value="0.0008"> <!-- long to fully remedy with just above temps and lead fouling -->
+            systems/propulsion/sparkplugs/temperature-degf-tgt LT 650.0
+            systems/propulsion/sparkplugs/left/fouling-change  LT 0
+            systems/propulsion/sparkplugs/left/lead-fouling    LE 0
+        </test>
+        <test logic="AND" value="0.033"> <!-- ~30s to fully remedy -->
+            systems/propulsion/sparkplugs/left/fouling-change LT 0
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/left/affected-switch">
+        <default value="systems/propulsion/sparkplugs/left/affected" />
+        <test logic="OR" value="1">  <!-- always affected if flooded, repairing or restoring -->
+            /systems/fuel/engine-flooded   EQ 1
+            /fdm/jsbsim/damage/repairing   EQ 1
+            /sim/time/elapsed-sec          LT 0.1
+        </test>
+        <test logic="AND" value="1">  <!-- always affected if cleaning and not affected otherwise -->
+            systems/propulsion/sparkplugs/left/affected        EQ 0
+            systems/propulsion/sparkplugs/left/fouling-change  LT 0
+        </test>
+    </switch>
+    <fcs_function name="systems/propulsion/sparkplugs/left/fouling-norm-ratelimit">
+        <function>
+            <product>
+                <property>systems/propulsion/sparkplugs/left/fouling-norm-ratelimit-swtch</property>
+                <property>systems/propulsion/sparkplugs/left/affected-switch</property>
+            </product>
+        </function>
+    </fcs_function>
+    <actuator name="systems/propulsion/sparkplugs/left/fouling-norm">
+        <input> systems/propulsion/sparkplugs/left/fouling-tgt </input>
+        <rate_limit>systems/propulsion/sparkplugs/left/fouling-norm-ratelimit</rate_limit> <!-- rate_limit defines change per second -->
+        <clipto>
+            <min> 0.00 </min>
+            <max> 1.00 </max>
+        </clipto>
+        <output>systems/propulsion/sparkplugs/left/fouling-savedrestore</output>
+    </actuator>
+    
+    
+    <!-- Right Spark plug fouling -->
+    <!-- The following switches calculate the fouling conditions -->
+    <switch name="systems/propulsion/sparkplugs/right/carbon-fouling">
+        <!-- Carbon fouling occurs with overly rich mixture.
+             AFR:  8=no combustion; <8.15 severe RPM loss; <12=rich; ~12.0 is MaxPWR; 13.9 is Peak ~EGT; > 13.9=LoP; ~18.9 engine cutoff-->
+        <default value="0"/>
+        <test logic="AND" value="1">
+            /engines/engine/running  EQ 1
+            propulsion/engine/AFR    LT 11.0
+        </test>
+        <test logic="AND" value="-1">
+            /engines/engine/running    EQ 1
+            propulsion/engine/AFR GT   11.5
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/right/lead-fouling">
+        <!-- Lead fouling occurs when the combustion temperature is not hot enough to activate
+             the EDB lead scavenge agent (temps < 264°C/507°F). -->
+        <default value="0"/>
+        <test logic="AND" value="1">
+            /engines/engine/running                     EQ 1
+            /engines/engine/sparkplugs-temperature-degf LT 507.2
+        </test>
+        <test logic="AND" value="-1">
+            /engines/engine/running                     EQ 1
+            /engines/engine/sparkplugs-temperature-degf GT 507.2
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/right/disabled-fouling">
+        <!-- The plug is not running but supplied with fuel. This will slowly foul (running on one magneto). -->
+        <!-- It will be removed if the plug is firing again in "cleaning" conditions. -->
+        <default value="0"/>
+        <test logic="AND" value="1">
+            <test logic="OR">
+                /engines/engine/running           EQ 1
+                /engines/engine/cranking          EQ 1
+            </test>
+            systems/propulsion/sparkplugs/right/magneto-selected EQ 0
+        </test>
+    </switch>
+    
+    <!-- This switch calculates the final decision if we should clean/foul the plugs -->
+    <switch name="systems/propulsion/sparkplugs/right/fouling-change">
+        <default value="0"/>
+        <test logic="AND" value="0">
+            <!-- Do not change the value if simulation is not activated -->
+            /engines/engine/allow-sparkplug-icing EQ 0
+        </test>
+        <test logic="OR" value="1">
+            systems/propulsion/sparkplugs/right/carbon-fouling   GT 0
+            systems/propulsion/sparkplugs/right/lead-fouling     GT 0
+            systems/propulsion/sparkplugs/right/disabled-fouling GT 0
+        </test>
+        <test logic="AND" value="-1">
+            systems/propulsion/sparkplugs/right/carbon-fouling LT 0
+            systems/propulsion/sparkplugs/right/lead-fouling   LE 0
+        </test>
+        <test logic="AND" value="-1">
+            systems/propulsion/sparkplugs/right/carbon-fouling LE 0
+            systems/propulsion/sparkplugs/right/lead-fouling   LT 0
+        </test>
+    </switch>
+    
+    <!-- Calculate decrease/stable/increase of plugs foul state
+         (the switch has three states: 0=stable; -1/+1=clean/foul;
+          and the increase/decrease rate is dynamic. Finally, the
+          actuator represents the current fouling-state in percent -->
+    <switch name="systems/propulsion/sparkplugs/right/fouling-tgt">
+        <default value="systems/propulsion/sparkplugs/right/fouling-norm"/>
+        <test logic="AND" value="0.0">
+            /fdm/jsbsim/damage/repairing EQ 1
+        </test>
+        <test logic="AND" value="systems/propulsion/sparkplugs/right/fouling-savedrestore">
+            /sim/time/elapsed-sec        LT 0.1
+        </test>
+        <test logic="AND" value="1.0"> <!-- Flooded engine makes plugs wet/fouled -->
+            /engines/engine/running      EQ 0
+            /systems/fuel/engine-flooded EQ 1
+        </test>
+        <test logic="AND" value="1.0">
+            /engines/engine/running EQ 1
+            systems/propulsion/sparkplugs/right/fouling-change GT 0
+        </test>
+        <test logic="AND" value="0.0">
+            /engines/engine/running EQ 1
+            systems/propulsion/sparkplugs/right/fouling-change LT 0
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/right/fouling-norm-ratelimit-swtch">
+        <default value="0"/>
+        <test logic="OR" value="999"> <!-- insta repair/restore -->
+            /fdm/jsbsim/damage/repairing EQ 1
+            /sim/time/elapsed-sec        LT 0.1
+        </test>
+        <test logic="AND" value="0.50"> <!-- Flooded engine makes plugs fouled -->
+            /engines/engine/running      EQ 0
+            /systems/fuel/engine-flooded EQ 1
+        </test>
+        <test logic="AND" value="0.00166"> <!-- ~10min=600s to fully develop -->
+            systems/propulsion/sparkplugs/right/fouling-change GT 0
+        </test>
+        <test logic="AND" value="0.0005"> <!-- long to fully remedy with just above temps and lead fouling -->
+            systems/propulsion/sparkplugs/temperature-degf-tgt  LT 650.0
+            systems/propulsion/sparkplugs/right/fouling-change  LT 0
+            systems/propulsion/sparkplugs/right/lead-fouling    LE 0
+        </test>
+        <test logic="AND" value="0.0008"> <!-- long to fully remedy with just above temps and lead fouling -->
+            systems/propulsion/sparkplugs/temperature-degf-tgt  LT 730.0
+            systems/propulsion/sparkplugs/right/fouling-change  LT 0
+            systems/propulsion/sparkplugs/right/lead-fouling    LE 0
+        </test>
+        <test logic="AND" value="0.033"> <!-- ~30s to fully remedy -->
+            systems/propulsion/sparkplugs/right/fouling-change LT 0
+        </test>
+    </switch>
+    <switch name="systems/propulsion/sparkplugs/right/affected-switch">
+        <default value="systems/propulsion/sparkplugs/right/affected" />
+        <test logic="OR" value="1">  <!-- always affected if flooded, repairing or restoring -->
+            /systems/fuel/engine-flooded   EQ 1
+            /fdm/jsbsim/damage/repairing   EQ 1
+            /sim/time/elapsed-sec          LT 0.1
+        </test>
+        <test logic="AND" value="1">  <!-- always affected if cleaning and not affected otherwise -->
+            systems/propulsion/sparkplugs/right/affected        EQ 0
+            systems/propulsion/sparkplugs/right/fouling-change  LT 0
+        </test>
+    </switch>
+    <fcs_function name="systems/propulsion/sparkplugs/right/fouling-norm-ratelimit">
+        <function>
+            <product>
+                <property>systems/propulsion/sparkplugs/right/fouling-norm-ratelimit-swtch</property>
+                <property>systems/propulsion/sparkplugs/right/affected-switch</property>
+            </product>
+        </function>
+    </fcs_function>
+    <actuator name="systems/propulsion/sparkplugs/right/fouling-norm">
+        <input> systems/propulsion/sparkplugs/right/fouling-tgt </input>
+        <rate_limit>systems/propulsion/sparkplugs/right/fouling-norm-ratelimit</rate_limit> <!-- rate_limit defines change per second -->
+        <clipto>
+            <min> 0.00 </min>
+            <max> 1.00 </max>
+        </clipto>
+        <output>systems/propulsion/sparkplugs/right/fouling-savedrestore</output>
+    </actuator>
+
+
+    <!-- Calculate engine roughness factor
+         This is based on the fouling state, the magneto settings and also RPM.
+    NOTE: Fyling on BOTH should be better than on the good mag alone, unless the
+         engine runs rough in BOTH. This (probably?) happens, when the bad magneto hinders the good one
+         more than the good one can overcome; so switching to the better one in this case gives more power
+         and a less rough engine.
+    -->
+    <fcs_function name="systems/propulsion/sparkplugs/fouling-roughness-factor">
+        <description>made up data for spark plug fouling power loss/engine roughness </description>
+        <function>
+            <product>
+                <!-- Only add roughness if extended simulation is switched on -->
+                <property>/engines/engine/complex-engine-procedures</property>
+                <property>/engines/engine/allow-sparkplug-icing</property>
+                
+                <sum>
+                    <!-- LEFT magneto selected -->
+                    <product>
+                        <property>systems/propulsion/sparkplugs/left/magneto-selected</property>
+                        <not><property>systems/propulsion/sparkplugs/right/magneto-selected</property></not>
+                        
+                        <table>
+                            <independentVar>systems/propulsion/sparkplugs/left/fouling-norm</independentVar>
+                            <tableData>
+                                0.00   0.00
+                                0.33   0.00
+                                1.00   1.00
+                            </tableData>
+                        </table>
+                    </product>
+                    
+                    <!-- RIGHT magneto selected -->
+                    <product>
+                        <not><property>systems/propulsion/sparkplugs/left/magneto-selected</property></not>
+                        <property>systems/propulsion/sparkplugs/right/magneto-selected</property>
+                        
+                        <table>
+                            <independentVar>systems/propulsion/sparkplugs/right/fouling-norm</independentVar>
+                            <tableData>
+                                0.00   0.00
+                                0.33   0.00
+                                1.00   1.00
+                            </tableData>
+                        </table>
+                    </product>
+                    
+                    <!-- BOTH magnetos selected -->
+                    <product>
+                        <property>systems/propulsion/sparkplugs/left/magneto-selected</property>
+                        <property>systems/propulsion/sparkplugs/right/magneto-selected</property>
+                        
+                        <table>
+                            <independentVar lookup="row">systems/propulsion/sparkplugs/left/fouling-norm</independentVar>
+                            <independentVar lookup="column">systems/propulsion/sparkplugs/right/fouling-norm</independentVar>
+                            <tableData>
+                                      0.00   0.30   1.00
+                                0.00  0      0      0.30
+                                0.30  0      0      0.45
+                                1.00  0.30   0.45   0.60
+                            </tableData>
+                        </table>
+                    </product>
                 </sum>
-                <value>2</value>
-            </quotient>
+                
+                <table>
+                    <independentVar>propulsion/engine/engine-rpm</independentVar>
+                    <tableData>
+                        1300  0.0
+                        2400  1.0
+                    </tableData>
+                </table>
+            </product>
+            
         </function>
     </fcs_function>
 
@@ -174,7 +626,7 @@
                for a defined ammount of time, additional friction is applied that will kill the engine.
             
     -->
-    <channel name="Engine Friction">
+    <channel name="Engine Friction" execrate="8">
         <fcs_function name="systems/propulsion/expansion-friction">
             <description>made up data to simulate too hot CHT causing friction</description>
             <function>
@@ -327,6 +779,20 @@
         </fcs_function>
         
         
+        <!-- Power-loss friction -->
+        <!-- TODO: This currently seems to be the only reliable way to reduce power without other side effects... -->
+        <fcs_function name="systems/propulsion/friction-powerloss">
+            <function>
+                <table>
+                    <independentVar>systems/engine/power-reduction-pct</independentVar>
+                    <tableData>
+                        0.0     0.0
+                        1.0   230.0
+                    </tableData>
+                </table>
+            </function>
+        </fcs_function>
+        
         
         <!-- TODO: it is possible model existing stuff here, like fuel tanks contaminated and prop-strike; -->
         
@@ -334,16 +800,17 @@
         
         
 
-        <!-- sum up all friction variables and output to jsbsim, affecting engine RPM -->
+        <!-- sum up all friction variables and output to jsbsim, affecting engine RPM and heat generation-->
         <summer name="systems/propulsion/friction-summer">
             <!--<bias> 0.5 </bias>-->
+            <input> systems/propulsion/manual-friction </input>     <!-- we might have fun trough telnet/scripts... -->
             <input> systems/propulsion/oil-age-friction </input>
             <input> systems/propulsion/oil-temp-friction </input>
             <input> systems/propulsion/oil-press-friction </input>
             <input> systems/propulsion/expansion-friction </input>
             <input> systems/propulsion/friction-kill-engine </input>
-            <input> systems/propulsion/manual-friction </input>     <!-- we might have fun trough telnet/scripts... -->
             <input> systems/propulsion/friction-crashed-engine </input>
+            <input> systems/propulsion/friction-powerloss </input>
             <!-- TODO: <input> prop-strike </input> -->
             <!-- TODO: <input> fuel-contaminated </input> -->
             <output>propulsion/engine/friction-hp</output>

--- a/Systems/propulsion.xml
+++ b/Systems/propulsion.xml
@@ -34,31 +34,53 @@
 	
 
 
-        <!-- Power based on fuel flow-->
+        <!-- Power based on fuel flow -->
         <fcs_function name="systems/engine/MP-alt-bsfc-lbs_hphr-curve">
           <function>
             <table>
                 <independentVar lookup="row">atmosphere/density-altitude</independentVar>
                 <independentVar lookup="column">propulsion/engine/fuel-flow-rate-gph</independentVar>
                 <tableData breakPoint="0">
-				8.0	9.0	13.5	14.5	15.5	16.5	17.5	19.0	20.5	21.5
-		0		0.360	0.360	0.36	0.415	0.425	0.425	0.437	0.455	0.475 0.53
-		2000		0.355	0.355	0.355	0.415	0.425	0.425	0.457	0.475	0.53 0.53
-		4000		0.355	0.355	0.420	0.415	0.425	0.425	0.437	0.53	0.53 0.53
-		6000		0.345	0.355	0.367	0.415	0.425	0.425	0.53	0.53	0.53 0.53
-		8000		0.345	0.360	0.360	0.415	0.425	0.425	0.53	0.53	0.53 0.53
-		10000	0.370	0.310	0.415	0.415	0.437	0.53	0.53	0.53	0.53 0.53
-		12000	0.395	0.335	0.415	0.435	0.53	0.53	0.53	0.53	0.53 0.53
-		14000	0.360	0.332	0.445	0.53	0.53	0.53 0.53 0.53	0.53 0.53
+                             8.0      9.0     13.5    14.5    15.5    16.5    17.5    19.0    20.5    21.5
+                    0        0.360    0.360    0.36    0.415   0.425   0.425   0.437   0.455   0.475   0.53
+                    2000     0.355    0.355    0.355   0.415   0.425   0.425   0.457   0.475   0.53    0.53
+                    4000     0.355    0.355    0.420   0.415   0.425   0.425   0.437   0.53    0.53    0.53
+                    6000     0.345    0.355    0.367   0.415   0.425   0.425   0.53    0.53    0.53    0.53
+                    8000     0.345    0.360    0.360   0.415   0.425   0.425   0.53    0.53    0.53    0.53
+                    10000    0.370    0.310    0.415   0.415   0.437   0.53    0.53    0.53    0.53    0.53
+                    12000    0.395    0.335    0.415   0.435   0.53    0.53    0.53    0.53    0.53    0.53
+                    14000    0.360    0.332    0.445   0.53    0.53    0.53    0.53    0.53    0.53    0.53
                 </tableData>
-            </table>  
+            </table>
           </function>
           <clipto>
              <min> 0.0 </min>
              <max> 1.00 </max>
            </clipto>
-          <output>propulsion/engine/bsfc-lbs_hphr</output>   
         </fcs_function>
+        
+        <!-- Adjust bsfc for power-loss factors (the higher the value, the less power per unit of fuel) -->
+        <fcs_function name="systems/engine/BSFC">
+          <function>
+              <product>
+                  <property>systems/engine/MP-alt-bsfc-lbs_hphr-curve</property>
+                  <table>
+                    <independentVar>systems/engine/power-reduction-pct</independentVar>
+                    <tableData>
+                        0.00  1.00
+                        0.50  1.60
+                        0.75  3.20
+                        1.0   5.00
+                    </tableData>
+                </table>
+              </product>
+          </function>
+          <clipto>
+             <min> 0.0001 </min> <!-- <=0 breaks the fdm! -->
+           </clipto>
+           <output>propulsion/engine/bsfc-lbs_hphr</output>   <!-- consumed by jsbsim -->
+        </fcs_function>
+        
 	
         <fcs_function name="systems/engine/RAM-Air-Factor">
           <function>
@@ -603,8 +625,9 @@
                 <table>
                     <independentVar>propulsion/engine/engine-rpm</independentVar>
                     <tableData>
-                        1300  0.0
-                        2400  1.0
+                        1300  0.00
+                        1700  0.75
+                        2400  1.00
                     </tableData>
                 </table>
             </product>
@@ -779,21 +802,6 @@
         </fcs_function>
         
         
-        <!-- Power-loss friction -->
-        <!-- TODO: This currently seems to be the only reliable way to reduce power without other side effects... -->
-        <fcs_function name="systems/propulsion/friction-powerloss">
-            <function>
-                <table>
-                    <independentVar>systems/engine/power-reduction-pct</independentVar>
-                    <tableData>
-                        0.0     0.0
-                        1.0   230.0
-                    </tableData>
-                </table>
-            </function>
-        </fcs_function>
-        
-        
         <!-- TODO: it is possible model existing stuff here, like fuel tanks contaminated and prop-strike; -->
         
         
@@ -810,7 +818,6 @@
             <input> systems/propulsion/expansion-friction </input>
             <input> systems/propulsion/friction-kill-engine </input>
             <input> systems/propulsion/friction-crashed-engine </input>
-            <input> systems/propulsion/friction-powerloss </input>
             <!-- TODO: <input> prop-strike </input> -->
             <!-- TODO: <input> fuel-contaminated </input> -->
             <output>propulsion/engine/friction-hp</output>

--- a/Tutorials/sparkPlugFouling.xml
+++ b/Tutorials/sparkPlugFouling.xml
@@ -1,0 +1,608 @@
+<?xml version="1.0"?>
+<PropertyList>
+
+    <name>Engine handling: Idling, Magneto checks and Spark plug fouling</name>
+
+    <description>
+The engines features six cylinders, which each have two spark plugs that are wired to separate magnetos.
+Some conditions can lead to accumlation of electrically conductive deposits on the plugs, eventually shorting
+the circuits and disabling the spark plug. This leads to misfires, a rough engine and reduced power.
+
+This 10 minutes long Tutorial will show you the effects and how to avoid and remedy them.
+Please start it parked on ground.
+
+
+----------------
+To avoid spark plug fouling:
+ - All ground operations: lean to peak EGT, throttle 1000-1200
+ - Target: keep the combustion above 264 degC/507degF
+ - A lean mixture burns hotter than a rich one
+ - In winter preheat the engine and use the winter kit
+ - In cruise lean properly
+ - After flight before stopping the engine, for 20 seconds set mixture lean,
+   1800 RPM, then reduce to 1000 RPM and stop the engine by pulling mixture to cut-off.
+
+To clean the spark plugs on the ground:
+- Throttle 1800 RPM
+- Mixture 50° lean of Peak
+- Run for about 30 seconds and then reduce power in order to not overheat (watch CHT!)
+- Verify with magneto check (Full rich, 1800 RPM, switch LEFT -> BOTH -> RIGHT -> BOTH, 1000 RPM)
+  Drop must not exceed 150 RPM for single magneto operation and no more than 50 RPM between magnetos
+- repeat two times if needed, after that repair the plane
+In cruise, the problem should resolve within one or two minutes when properly leaned
+    </description>
+    
+    <interval>10</interval>
+    <step-time>2</step-time>
+    <exit-time>2</exit-time>
+    
+    <init>
+        <nasal>
+            <script>
+                c182s.repair_damage();
+            </script>
+        </nasal>
+        <set>
+            <property>/sim/model/c182s/brake-parking</property>
+            <value>1</value>
+        </set>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/affected</property>
+            <value>0</value>
+        </set>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/left/affected</property>
+            <value>0</value>
+        </set>
+    </init>
+    
+    <step>
+        <message>In this lesson, you'll learn how to properly idle the engine to avoid fouled spark plugs.
+            Also, I will show you how you can clean the plugs from deposits.</message>
+        <wait>8</wait>
+    </step>
+    
+    <step>
+        <message>The simulation is only active, if you have the aircraft options 'complex engine procedures'
+            and 'Spark plug icing/fouling' active. You can find them in the aircraft dialog menu. </message>
+        <wait>5</wait>
+        
+    </step>
+    <step>
+        <message />
+        <wait>5</wait>
+        <nasal>
+            <script>
+                if (!getprop("/engines/engine/complex-engine-procedures")
+                or  !getprop("/engines/engine/allow-sparkplug-icing") )
+                    fgcommand("dialog-show", {"dialog-name": "aircraft-dialog"});
+            </script>
+        </nasal>
+        <error>
+            <message>Activate the complex 'engine procedures' and 'Spark plug icing/fouling' simulation options.</message>
+            <condition>
+                <or>
+                    <not><property>/engines/engine/complex-engine-procedures</property></not>
+                    <not><property>/engines/engine/allow-sparkplug-icing</property></not>
+                </or>
+            </condition>
+        </error>
+    </step>
+    
+    <step>
+        <condition>
+            <or>
+                <not><property>/engines/engine/running</property></not>
+                <property>/controls/engines/engine[0]/throttle</property>
+                <property>/controls/engines/engine[0]/mixture</property>
+            </or>
+        </condition>
+        <message>Now please start your engine and put throttle to idle, mixture full rich.</message>
+        <wait>3</wait>
+        
+        <error>
+            <message>Please start the engine, throttle idle, mix full rich.</message>
+            <interval>10</interval>
+            <condition>
+                <or>
+                    <not><property>/engines/engine/running</property></not>
+                    <greater-than-equals>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <value>0.10</value>
+                    </greater-than-equals>
+                    <less-than-equals>
+                        <property>/controls/engines/engine[0]/mixture</property>
+                        <value>0.95</value>
+                    </less-than-equals>
+                </or>
+            </condition>
+        </error>
+    </step>
+    
+    <step>
+        <message>While the engine idles, it is still cold. Currently slowly lead oxide is forming on your spark plugs,
+            eventually shorting them. We just wait now for that to develop.</message>
+        <wait>25</wait>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/fouling-norm/malfunction/fail_hardover</property>
+            <value>1</value>
+        </set>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/affected</property>
+            <value>6</value>
+        </set>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/left/affected</property>
+            <value>0</value>
+        </set>
+
+    </step>
+    
+    <step>
+        <message>Usually the forming does take some time, but to shorten your waiting time, I acceleerated the effect.</message>
+        <wait>10</wait>
+        
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/fouling-norm</property>
+                    <value>0.95</value>
+                </less-than-equals>
+            </condition>
+            <message>Please wait and monitor your engine instruments.</message>
+            <interval>10</interval>
+        </error>
+        <error>
+            <condition>
+                <not><property>/engines/engine/running</property></not>
+            </condition>
+            <message>If the engine died of roughness, kindly advance throttle a little bit and restart using the 'S' key.</message>
+        </error>
+    </step>
+    
+    <step>
+        <message>Now some of the right magentos spark plugs are lead fouled. 
+            As you probably notice, there is no visible evidence of a fouled spark plug at low RPM settings.</message>
+        <wait>10</wait>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/affected</property>
+            <value>1</value>
+        </set>
+    </step>
+    
+    <step>
+        <message>One possible cause of Spark plug fouling is a cold combustion. This plane uses {AVGAS 100LL|Aviation Gas one hundred low lead} which has lead added
+            to make the engine run smoother. There are also EDB lead scavenge agents added to the fuel in order to
+            catch lead oxides. That agent is only working at combustion temperatures above 507 {degF|degree Fahrenheit}.</message>
+        <wait>21</wait>
+    </step>
+    
+    <step>
+        <message>If you would attempt to takeoff now you will observe dangerously reduced engine power.
+            This is why it is important to always do a proper engine runup. Lets check the plugs using the magneto check!</message>
+        <wait>15</wait>
+    </step>
+    
+    <step>
+        <message>To do this, we first set mixture full rich and throttle up to 1800 RPM,
+            then switch Magneto to the LEFT setting, back to BOTH, then to RIGHT, then to BOTH
+            and finally reduce power. If the check is made on ground, it should be carried out swiftly in order to not
+            overheat the engine. Always keep an eye on the CHT gauge!</message>
+        <wait>20</wait>
+        <error>
+            <condition>
+                <or>
+                    <less-than-equals>
+                        <property>/engines/engine/rpm</property>
+                        <value>1750</value>
+                    </less-than-equals>
+                    <greater-than-equals>
+                        <property>/engines/engine/rpm</property>
+                        <value>1850</value>
+                    </greater-than-equals>
+                </or>
+            </condition>
+            <message>Adjust throttle to set the engine to 1800 RPM, full rich</message>
+        </error>
+    </step>
+    <step>
+        <message>Now set the magneto to the LEFT setting, and go back to BOTH. Did you see the drop?{|,} It should not exceed 150 RPM compared to the BOTH setting.</message>
+        <wait>12</wait>
+    </step>
+    <step>
+        <message>Now set the magneto switch to RIGHT{|,} and back to BOTH afterwards. You should notice a heavy drop, exceeding the 150 RPM from the checklist.
+            This is proof that there is something wrong with the magneto or the spark plugs.</message>
+        <wait>13</wait>
+    </step>
+    <step>
+        <message>Seen the drop?{|,} OK, this time we know that the plugs have fouled. You should never take off with this condition!</message>
+        <wait>10</wait>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/rpm</property>
+                    <value>1250</value>
+                </greater-than-equals>
+            </condition>
+            <message>Don't forget to reduce power to {1000-1200|thousand to thousandtwohundred} RPM after the check!</message>
+        </error>
+    </step>
+    <step>
+        <condition>
+            <greater-than-equals>
+                <property>/engines/engine/cht-degf</property>
+                <value>300</value>
+            </greater-than-equals>
+        </condition>
+        <message>Let's cool the engine a bit, reduce power to 1000 RPM.</message>
+        <wait>10</wait>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/rpm</property>
+                    <value>1050</value>
+                </greater-than-equals>
+            </condition>
+        </error>
+    </step>
+    <step>
+        <message>The good news is that we can try to get rid of the lead deposits. For this we need a combustion temperature high enough to activate the lead scavenge agents.</message>
+        <wait>10</wait>
+    </step>
+    
+    <step>
+        <condition>
+            <greater-than-equals>
+                <property>/engines/engine/cht-degf</property>
+                <value>300</value>
+            </greater-than-equals>
+        </condition>
+        <message>Before starting, we need to cool down the cylinder a bit.</message>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>300</value>
+                </greater-than-equals>
+            </condition>
+            <message>Reduce power to 1000 RPM and let it cool to below 300 degree!</message>
+            <interval>5</interval>
+        </error>
+    </step>
+    
+    <step>
+        <message>All right, the engine should be cool enough to proceed with the cleaning procedure.</message>
+        <wait>5</wait>
+    </step>
+    
+    <step>
+        <message>Lean the mixture to achieve 50 degee lean of {EGT|E G T} peak and push the throttle in to set about 1800 RPM.</message>
+        <wait>10</wait>
+        <error>
+            <condition>
+                <or>
+                    <less-than-equals>
+                        <property>/engines/engine/rpm</property>
+                        <value>1700</value>
+                    </less-than-equals>
+                    <greater-than-equals>
+                        <property>/engines/engine/rpm</property>
+                        <value>1900</value>
+                    </greater-than-equals>
+                    <less-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>13.5</value>
+                    </less-than-equals>
+                    <greater-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>15.50</value>
+                    </greater-than-equals>
+                </or>
+            </condition>
+            <interval>2</interval>
+            <message>Lean to 50 degree lean of peak {EGT|E G T} and adjust throttle to set the engine to 1800 RPM
+                {(The EGT gauge's markings are 25 degF each)}</message>
+        </error>
+    </step>
+
+    <step>
+        <message>We need to run the engine for about {30|thirty} seconds on this setting.
+            This should clear the lead deposits.
+            Carefully watch the {CHT|C H T} and do not exceed limits.</message>
+        <wait>20</wait>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/fouling-norm/malfunction/fail_hardover</property>
+            <value>0</value>
+        </set>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/fouling-norm</property>
+                    <value>0.05</value>
+                </greater-than-equals>
+            </condition>
+            <message>There is still lead deposits, we need to burn off some more.</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>500</value>
+                </greater-than-equals>
+            </condition>
+            <message>Your {CHT|C H T} is too hot! add mixture and reduce throttle!</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit leaner (the leaner, the hotter) and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+    </step>
+    
+    <step>
+        <message>If you think you now got rid of the problem, reduce power to the proper setting: {1000-1200|thousand to thousandtwohundred} RPM, mixture leaned to peak {EGT|E G T} (or 50 degree less).</message>
+        <wait>10</wait>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/fouling-norm/malfunction/fail_hardover</property>
+            <value>0</value>
+        </set>
+        <error>
+            <condition>
+                <or>
+                    <less-than-equals>
+                        <property>/engines/engine/rpm</property>
+                        <value>990</value>
+                    </less-than-equals>
+                    <greater-than-equals>
+                        <property>/engines/engine/rpm</property>
+                        <value>1230</value>
+                    </greater-than-equals>
+                </or>
+            </condition>
+            <message>Adjust throttle to set the engine to {1000-1200|thousand to thousandtwohundred} RPM.</message>
+        </error>
+        <error>
+            <condition>
+                <or>
+                    <less-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>13.0</value>
+                    </less-than-equals>
+                    <greater-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>15.50</value>
+                    </greater-than-equals>
+                </or>
+            </condition>
+            <message>Don't forget to lean to peak {EGT|E G T} while idle!</message>
+        </error>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit lean of peak and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>500</value>
+                </greater-than-equals>
+            </condition>
+            <message>Your {CHT|C H T} is way too hot! add mixture and reduce throttle!</message>
+            <interval>15</interval>
+        </error>
+    </step>
+    
+    <step>
+        <message>You now can perform another magneto check to verify the problem is gone.
+            {Mixture full rich, 1800 RPM, Mags LEFT-BOTH-RIGHT-BOTH, must not exceed 150/50 RPM drop}</message>
+        <wait>35</wait>
+        <set>
+            <property>/fdm/jsbsim/systems/propulsion/sparkplugs/right/fouling-norm/malfunction/fail_hardover</property>
+            <value>0</value>
+        </set>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit lean of peak and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+    </step>
+    
+    <step>
+        <message />
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/rpm</property>
+                    <value>1250</value>
+                </greater-than-equals>
+            </condition>
+            <message>Don't forget to reduce power to {1000-1200|thousand to thousandtwohundred} RPM after the check!</message>
+        </error>
+        <error>
+            <condition>
+                <or>
+                    <less-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>13.0</value>
+                    </less-than-equals>
+                    <greater-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>15.50</value>
+                    </greater-than-equals>
+                </or>
+            </condition>
+            <message>Don't forget to lean to peak {EGT|E G T} while idle!</message>
+        </error>
+    </step>
+    
+    <step>
+        <message>Great! All looks good now. Every time you are on the ground, adjust RPM to be at {1000-1200|thousand to thousandtwohundred} RPM
+            and the mixture leaned properly. This also depends on the outside air temperature, so you just
+            want to make sure the combustion is hot enough for the EDB agents to work.</message>
+        <wait>20</wait>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit lean of peak and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>500</value>
+                </greater-than-equals>
+            </condition>
+            <message>Your {CHT|C H T} is too hot! add mixture and reduce throttle!</message>
+            <interval>15</interval>
+        </error>
+    </step>
+    <step>
+        <message>You can idle indefinitely on this setting, just keep an eye on your CHT to not overheat the engine.</message>
+        <wait>5</wait>
+        <error>
+            <condition>
+                <or>
+                    <less-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>13.0</value>
+                    </less-than-equals>
+                    <greater-than-equals>
+                        <property>/fdm/jsbsim/propulsion/engine/AFR</property>
+                        <value>15.50</value>
+                    </greater-than-equals>
+                </or>
+            </condition>
+            <message>Don't forget to lean to peak {EGT|E G T} while idle!</message>
+        </error>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit lean of peak and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>500</value>
+                </greater-than-equals>
+            </condition>
+            <message>Your {CHT|C H T} is way too hot! add mixture and reduce throttle!</message>
+            <interval>15</interval>
+        </error>
+    </step>
+    <step>
+        <message>If you taxi, you should pull the throttle out or otherwise you will quickly wear down your expensive brakes.</message>
+        <wait>8</wait>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit lean of peak and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>500</value>
+                </greater-than-equals>
+            </condition>
+            <message>Your {CHT|C H T} is way too hot! add mixture and reduce throttle!</message>
+            <interval>15</interval>
+        </error>
+    </step>
+    <step>
+        <message>When you are flying in cold weather or descending from high altitudes, keep an eye on the {CHT|C H T}. Do not let the engine cool down too much.
+            Plan your descend ahead! It it OK of course to put the throttle to idle if needed, but avoid cold {CHT|cylinder} for prolonged times.</message>
+        <wait>10</wait>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit lean of peak and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>500</value>
+                </greater-than-equals>
+            </condition>
+            <message>Your {CHT|C H T} is way too hot! add mixture and reduce throttle!</message>
+            <interval>15</interval>
+        </error>
+    </step>
+    <step>
+        <message>But, one more thing: there is another cause for spark plug fouling: carbon deposits! They form when the mixture is overly rich. So always remember to be leaned appropriately.
+            On higher airports for example, the {"full rich"|full rich} checklist item should not be followed by the letter, but better be leaned for peak {EGT|E G T} or max power.
+            Also, running on just one magneto will slowly foul the spark plugs of the inactive magneto.</message>
+        <wait>26</wait>
+        <error>
+            <condition>
+                <less-than-equals>
+                    <property>/engines/engine/sparkplugs-temperature-degf</property>
+                    <value>507</value>
+                </less-than-equals>
+            </condition>
+            <message>Your combustion seems to be too cold. Adjust mixture a bit lean of peak and recheck throttle.</message>
+            <interval>5</interval>
+        </error>
+        <error>
+            <condition>
+                <greater-than-equals>
+                    <property>/engines/engine/cht-degf</property>
+                    <value>500</value>
+                </greater-than-equals>
+            </condition>
+            <message>Your {CHT|C H T} is way too hot! add mixture and reduce throttle!</message>
+            <interval>15</interval>
+        </error>
+    </step>
+    
+    <step>
+        <message>When finally stopping the engine after parking, lean to peak EGT, set 1800 RPM for twenty seconds, reduce to 1000 RPM and stop the engine promptly by pulling mixture to the cut-off position.</message>
+        <wait>13</wait>
+    </step>
+    
+    <step>
+        <message>Tutorial complete. You now know how to avoid and clean fouled spark plugs and how to idle on ground.</message>
+         <wait>10</wait>
+    </step>
+
+
+</PropertyList>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -144,6 +144,7 @@
   <checklists include="c182s-checklists.xml"/>
 
   <tutorials>
+    <tutorial include="Tutorials/sparkPlugFouling.xml"/>
     <tutorial include="Tutorials/davtron803.xml"/>
   </tutorials>
 
@@ -947,6 +948,9 @@
             <path>/fdm/jsbsim/wing-damage/left-wing-saved</path>
             <path>/fdm/jsbsim/wing-damage/right-wing-saved</path>
 
+            <path>/fdm/jsbsim/systems/propulsion/sparkplugs/left/fouling-savedrestore</path>
+            <path>/fdm/jsbsim/systems/propulsion/sparkplugs/right/fouling-savedrestore</path>
+
             <path>/consumables/fuel/tank[0]/level-gal_us</path>
             <path>/consumables/fuel/tank[1]/level-gal_us</path>
             <path>/consumables/fuel/tank[2]/level-gal_us</path>
@@ -1311,6 +1315,8 @@
    <governor>
         <serviceable type="bool">true</serviceable>
     </governor>
+    <manual-roughness-factor type="double">0</manual-roughness-factor>
+    <manual-power-reduction-pct type="double">0</manual-power-reduction-pct>
   </engine>
  </engines>
 

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -135,6 +135,11 @@
   <aircraft-operator type="string">NONE</aircraft-operator>
   
   <checklists include="c182t-checklists.xml"/>
+  
+  <tutorials>
+    <!-- no Davtron clock in the T variant! <tutorial include="Tutorials/davtron803.xml"/> -->
+    <tutorial include="Tutorials/sparkPlugFouling.xml"/>
+  </tutorials>
 
   <virtual-cockpit>true</virtual-cockpit>
   <allow-toggle-cockpit>true</allow-toggle-cockpit>
@@ -1204,6 +1209,8 @@
    <governor>
         <serviceable type="bool">true</serviceable>
     </governor>
+    <manual-roughness-factor type="double">0</manual-roughness-factor>
+    <manual-power-reduction-pct type="double">0</manual-power-reduction-pct>
   </engine>
  </engines>
 

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -270,7 +270,7 @@
                     <layout>hbox</layout>
                     <checkbox>
                         <halign>left</halign>
-                        <label>  Allow Spark plug icing</label>
+                        <label>  Allow Spark plug icing/fouling</label>
                         <property>/engines/engine/allow-sparkplug-icing</property>
                         <live>true</live>
                         <enable>


### PR DESCRIPTION
**Adding Spark plug fouling**
- Detailed spark plug fouling engine simulation
- Insim Tutorial to show the effect and how to avoid/mitigate
- [Documentation.md](https://github.com/HHS81/c182s/blob/Issue-439_SparkPlugFouling/Documentation.md#complex-engine-procedures) updated
- Added roughness if one magneto has failed

A overly rich mixture or idling on the ground for too long with cold combustion will foul your spark plugs, making the engine run rough. At the engine run up, the magneto check will reveal fouled plugs. There is a procedure to clear fouled plugs.

----
**Internals:**
- The engine coughing functionality was refactored in a generic "rough engine" implementation. Now the nasal part is very generic and mostly modelled in engine.xml and propulsion.xml. In the future, new "rough engine" sources can easily be added.
- There can be various sources for a rough engine, and a rough engine leads to oscillating RPM and loss of power.
- The spark plug fouling implementation is nearly purely done in propulsion and engine jsbsim systems and modular:
  The calculation of the underlying physics (spark plug temperature, fouling state, etc) is modelled separately
from the effect (->rough engine).
- The fouling state is saved with the plane's savestate and restored on the next session.
- The simulation was bound to the already available "spark plug icing" aircraft option which got renamed to ".../fouling". This is disabled by default if not explicitely activated from the pilot in the past.

- To express the effects, a new "power loss" effect is introduced; which is implemented currently by adjusting
a new friction source. If better options get available, we can switch the effects expression method easily.

- The systems are now also running on less-than-fcs fps to conserve CPU.

------
Fix #439