### PR TITLE
Revise engine cylinder head mass

### DIFF
--- a/Engines/engIO540AB1A5.xml
+++ b/Engines/engIO540AB1A5.xml
@@ -21,7 +21,7 @@
     <stroke unit="IN">4.375</stroke>
     <static-friction>1.5</static-friction>
     <cylinders> 6 </cylinders>
-    <cylinder-head-mass unit="KG"> 4 </cylinder-head-mass>
+    <cylinder-head-mass unit="LBS"> 21.75 </cylinder-head-mass>  <!-- Part No. LW-13870 / MFR Model# 16A30080-03; 21.75lbs -->
     <compression-ratio>8.7</compression-ratio>
     <volumetric-efficiency>0.88</volumetric-efficiency>
     <bsfc unit="LBS/HP*HR">0.445</bsfc>


### PR DESCRIPTION
Previously we used 4Kg as arbitarily choosen head mass.
I found a shop listing a cylinder head at 21.7 lbs (~9.85 Kg; complete engine is 400 lbs according to POH 6-22).

Fix #444