### PR TITLE
Add skydiving option

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -145,8 +145,7 @@ The lower LCD row displays four different timing information, the active mode is
   - You can setup an countdown timer by by pressing the _select_ and _control_ buttons together (**shift-click one of the two buttons**). Enter the digits like just described at the FT alarm mode. After confirming the last digit, the countdown is armed and ready to be started by another press of _control_. The alarm will go off once the countdown reaches zero. You can confirm the the alarm by either pressing _select_ or _control_.
 
 
-Dual Control feature
--------------------------
+### Dual Control feature
 You can join a remote pilot as copilot! The pilot just uses the normal C182S Aircraft while the copilot must start the special "CoPilot" aircraft variant (select from the launcher).
 
 Once connected to the multiplayer server, both select each other trough the multiplayer menu entry *Select dual-control MP-pilot*:
@@ -157,6 +156,15 @@ Once connected to the multiplayer server, both select each other trough the mult
 The C182S and C182T are equipped with an tow hook and can tow any JSBSim/YASIM glider compatible to FlightGears standard implementation.
 
 Once the glider pilot hooked into your Cessna, you can press `SHIFT-O` to release the hook. For connecting, get close infront of the glider. When accelerating, do it with caution, otherwise the rope my rip. Expect also other airplane behaviour when towing (longer takeoff roll, etc).
+
+
+### Skydiving plane
+In the Aircraft options menu you can reconfigure the plane to haul up skydivers. This will remove the seats and the door.
+When on target altitude, just click on the passengers to make them jump out. Alternatively, you can use the "Jump!" button
+from the aircraft options menu to make them all jump out one after another.  
+Only passengers inside the plane will jump out, so add them using the "fuel and payload" settings dialog.  
+Jump procedure is that they will crawl outside to the strut, then release; so plan for the drag.
+
 
 
 FAQ

--- a/Models/Human/copilot.xml
+++ b/Models/Human/copilot.xml
@@ -188,6 +188,79 @@
   <y-offset>0.98</y-offset>
   <z-offset>0.98</z-offset>
  </animation>
-
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>translate</type>
+    <property>sim/model/crew/pilot[1]/pose/position/limb[0]/x-m</property>
+    <center>
+        <x-m>0.01</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.1</z-m>
+    </center>
+    <axis>
+        <x>1.0</x>
+        <y>0.0</y>
+        <z>0.0</z>
+    </axis>
+</animation>
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>translate</type>
+    <property>sim/model/crew/pilot[1]/pose/position/limb[0]/z-m</property>
+    <center>
+        <x-m>0.01</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.1</z-m>
+    </center>
+    <axis>
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>1.0</z>
+    </axis>
+</animation>
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>rotate</type>
+    <property>sim/model/crew/pilot[1]/pose/position/limb[0]/z-deg</property>
+    <center>
+        <x-m>0.0</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.0</z-m>
+    </center>
+    <axis>
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>1.0</z>
+    </axis>
+</animation>
+ <animation>
+    <type>pick</type>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <visible>true</visible>
+    <condition>
+        <and>
+            <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+        </and>
+    </condition>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>c182s.parajump(1);</script>
+        </binding>
+    </action>
+    <hovered>
+        <binding>
+            <command>set-tooltip</command>
+            <tooltip-id>copilot-jump</tooltip-id>
+            <label>Jump!</label>
+        </binding>
+    </hovered>
+</animation>
 
 </PropertyList>

--- a/Models/Human/humans-pax-parachuters.xml
+++ b/Models/Human/humans-pax-parachuters.xml
@@ -122,10 +122,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <rest-sec type="double">0</rest-sec>
           <transit-sec type="double">1</transit-sec>
           <limb> <!-- hip -->
-            <y-deg type="double">11.0959</y-deg>
-            <z-deg type="double">0</z-deg>
-            <x-m type="double">0</x-m>
-            <z-m type="double">0</z-m>
+            <y-deg type="double">5.0</y-deg>
+            <z-deg type="double">180</z-deg>
+            <x-m type="double">-0.58</x-m>
+            <z-m type="double">-0.15</z-m>
           </limb>
           <limb n="1"> <!-- chest -->
             <y-deg type="double">-7</y-deg>
@@ -138,10 +138,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <limb n="3"> <!-- arm1.R -->
             <x-deg type="double">-90</x-deg>
             <y-deg type="double">3</y-deg>
-            <z-deg type="double">-25</z-deg>
+            <z-deg type="double">-50</z-deg>
           </limb>
           <limb n="4"> <!-- arm2.R -->
-            <y-deg type="double">0</y-deg>
+            <y-deg type="double">-13</y-deg>
             <z-deg type="double">31.5287</z-deg>
           </limb>
           <limb n="5">  <!-- hand.R -->
@@ -152,7 +152,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <limb n="6"> <!-- arm1.L -->
             <x-deg type="double">-80</x-deg>
             <y-deg type="double">6.20689</y-deg>
-            <z-deg type="double">-17</z-deg>
+            <z-deg type="double">-50</z-deg>
           </limb>
           <limb n="7"> <!-- arm2.L -->
             <y-deg type="double">0</y-deg>
@@ -164,8 +164,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <hand-pose type="double">0</hand-pose> <!-- 1 == grip -->
           </limb>
           <limb n="9"> <!-- leg1.R -->
-            <x-deg type="double">0</x-deg>
-            <y-deg type="double">-95</y-deg>
+            <x-deg type="double">65</x-deg>
+            <y-deg type="double">-125</y-deg>
             <z-deg type="double">0</z-deg>
           </limb>
           <limb n="10"> <!-- leg2.R -->
@@ -175,12 +175,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <y-deg type="double">0</y-deg>
           </limb>
           <limb n="12"> <!-- leg1.L -->
-            <x-deg type="double">0</x-deg>
-            <y-deg type="double">-95</y-deg>
+            <x-deg type="double">75</x-deg>
+            <y-deg type="double">-125</y-deg>
             <z-deg type="double">0</z-deg>
           </limb>
           <limb n="13"> <!-- leg2.L -->
-            <y-deg type="double">50</y-deg>
+            <y-deg type="double">30</y-deg>
           </limb>
           <limb n="14"> <!-- foot.L -->
             <y-deg type="double">0</y-deg>
@@ -190,10 +190,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <character>0</character>
       <gender>1</gender>
       <hair>1</hair>
-      <outfit>0</outfit>
+      <outfit>1</outfit>
       <equipment>0</equipment>
       <eyewear>1</eyewear>
-      <headgear>1</headgear>
+      <headgear>0</headgear>
       <enabled type="bool">1</enabled>
     </pilot>
   </crew>
@@ -210,9 +210,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <transit-sec type="double">1</transit-sec>
           <limb> <!-- hip -->
             <y-deg type="double">11.0959</y-deg>
-            <z-deg type="double">0</z-deg>
-            <x-m type="double">0</x-m>
-            <z-m type="double">0</z-m>
+            <z-deg type="double">180</z-deg>
+            <x-m type="double">-0.2</x-m>
+            <z-m type="double">-0.10</z-m>
           </limb>
           <limb n="1"> <!-- chest -->
             <y-deg type="double">-7</y-deg>
@@ -251,9 +251,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <hand-pose type="double">0</hand-pose> <!-- 1 == grip -->
           </limb>
           <limb n="9"> <!-- leg1.R -->
-            <x-deg type="double">0</x-deg>
-            <y-deg type="double">-110</y-deg>
-            <z-deg type="double">0</z-deg>
+            <x-deg type="double">53</x-deg>
+            <y-deg type="double">-120</y-deg>
+            <z-deg type="double">20</z-deg>
           </limb>
           <limb n="10"> <!-- leg2.R -->
             <y-deg type="double">80</y-deg>
@@ -263,11 +263,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </limb>
           <limb n="12"> <!-- leg1.L -->
             <x-deg type="double">0</x-deg>
-            <y-deg type="double">-110</y-deg>
+            <y-deg type="double">-90</y-deg>
             <z-deg type="double">0</z-deg>
           </limb>
           <limb n="13"> <!-- leg2.L -->
-            <y-deg type="double">80</y-deg>
+            <y-deg type="double">-3</y-deg>
           </limb>
           <limb n="14"> <!-- foot.L -->
             <y-deg type="double">0</y-deg>
@@ -277,9 +277,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <character>0</character>
       <gender>1</gender>
       <hair>1</hair>
-      <outfit>2</outfit>
+      <outfit>1</outfit>
       <equipment>0</equipment>
-      <eyewear>0</eyewear>
+      <eyewear>1</eyewear>
       <headgear>0</headgear>
       <enabled type="bool">1</enabled>
     </pax>
@@ -295,9 +295,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <transit-sec type="double">1</transit-sec>
           <limb> <!-- hip -->
             <y-deg type="double">11.0959</y-deg>
-            <z-deg type="double">0</z-deg>
-            <x-m type="double">0</x-m>
-            <z-m type="double">0</z-m>
+            <z-deg type="double">180</z-deg>
+            <x-m type="double">-0.85</x-m>
+            <z-m type="double">-0.12</z-m>
           </limb>
           <limb n="1"> <!-- chest -->
             <y-deg type="double">-7</y-deg>
@@ -305,7 +305,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </limb>
           <limb n="2"> <!-- head -->
             <y-deg type="double">-8.7222</y-deg>
-            <z-deg type="double">25</z-deg>
+            <z-deg type="double">-45</z-deg>
           </limb>
           <limb n="3"> <!-- arm1.R -->
             <x-deg type="double">-90</x-deg>
@@ -314,7 +314,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </limb>
           <limb n="4"> <!-- arm2.R -->
             <y-deg type="double">0</y-deg>
-            <z-deg type="double">65</z-deg>
+            <z-deg type="double">58</z-deg>
           </limb>
           <limb n="5">  <!-- hand.R -->
             <x-deg type="double">0</x-deg>
@@ -323,8 +323,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </limb>
           <limb n="6"> <!-- arm1.L -->
             <x-deg type="double">-65</x-deg>
-            <y-deg type="double">-5</y-deg>
-            <z-deg type="double">-85</z-deg>
+            <y-deg type="double">30</y-deg>
+            <z-deg type="double">-25</z-deg>
           </limb>
           <limb n="7"> <!-- arm2.L -->
             <y-deg type="double">0</y-deg>
@@ -332,16 +332,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           </limb>
           <limb n="8"> <!-- hand.L -->
             <x-deg type="double">0</x-deg>
-            <y-deg type="double">0</y-deg>
+            <y-deg type="double">-30</y-deg>
             <hand-pose type="double">1</hand-pose> <!-- 1 == grip -->
           </limb>
           <limb n="9"> <!-- leg1.R -->
-            <x-deg type="double">0</x-deg>
-            <y-deg type="double">-110</y-deg>
-            <z-deg type="double">0</z-deg>
+            <x-deg type="double">15</x-deg>
+            <y-deg type="double">-105</y-deg>
+            <z-deg type="double">15</z-deg>
           </limb>
           <limb n="10"> <!-- leg2.R -->
-            <y-deg type="double">80</y-deg>
+            <y-deg type="double">20</y-deg>
           </limb>
           <limb n="11"> <!-- foot.R -->
             <y-deg type="double">0</y-deg>
@@ -352,7 +352,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <z-deg type="double">0</z-deg>
           </limb>
           <limb n="13"> <!-- leg2.L -->
-            <y-deg type="double">80</y-deg>
+            <y-deg type="double">30</y-deg>
           </limb>
           <limb n="14"> <!-- foot.L -->
             <y-deg type="double">0</y-deg>
@@ -362,9 +362,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <character>0</character>
       <gender>0</gender>
       <hair>1</hair>
-      <outfit>0</outfit>
+      <outfit>1</outfit>
       <equipment>0</equipment>
-      <eyewear>0</eyewear>
+      <eyewear>1</eyewear>
       <headgear>0</headgear>
       <enabled type="bool">1</enabled>
     </pax>

--- a/Models/Human/pax0.xml
+++ b/Models/Human/pax0.xml
@@ -195,6 +195,80 @@
   <y-offset>0.95</y-offset>
   <z-offset>0.95</z-offset>
  </animation>
+ <animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>translate</type>
+    <property>sim/model/pax/pax[0]/pose/position/limb[0]/x-m</property>
+    <center>
+        <x-m>0.01</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.1</z-m>
+    </center>
+    <axis>
+        <x>1.0</x>
+        <y>0.0</y>
+        <z>0.0</z>
+    </axis>
+</animation>
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>translate</type>
+    <property>sim/model/pax/pax[0]/pose/position/limb[0]/z-m</property>
+    <center>
+        <x-m>0.01</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.1</z-m>
+    </center>
+    <axis>
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>1.0</z>
+    </axis>
+</animation>
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>rotate</type>
+    <property>sim/model/pax/pax[0]/pose/position/limb[0]/z-deg</property>
+    <center>
+        <x-m>0.0</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.0</z-m>
+    </center>
+    <axis>
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>1.0</z>
+    </axis>
+</animation>
 
+ <animation>
+    <type>pick</type>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <visible>true</visible>
+    <condition>
+        <and>
+            <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+        </and>
+    </condition>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>c182s.parajump(2);</script>
+        </binding>
+    </action>
+    <hovered>
+        <binding>
+            <command>set-tooltip</command>
+            <tooltip-id>pax1-jump</tooltip-id>
+            <label>Jump!</label>
+        </binding>
+    </hovered>
+ </animation>
 
 </PropertyList>

--- a/Models/Human/pax1.xml
+++ b/Models/Human/pax1.xml
@@ -195,6 +195,81 @@
   <y-offset>0.95</y-offset>
   <z-offset>0.95</z-offset>
  </animation>
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>translate</type>
+    <property>sim/model/pax/pax[1]/pose/position/limb[0]/x-m</property>
+    <center>
+        <x-m>0.01</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.1</z-m>
+    </center>
+    <axis>
+        <x>1.0</x>
+        <y>0.0</y>
+        <z>0.0</z>
+    </axis>
+</animation>
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>translate</type>
+    <property>sim/model/pax/pax[1]/pose/position/limb[0]/z-m</property>
+    <center>
+        <x-m>0.01</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.1</z-m>
+    </center>
+    <axis>
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>1.0</z>
+    </axis>
+</animation>
+<animation>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <type>rotate</type>
+    <property>sim/model/pax/pax[1]/pose/position/limb[0]/z-deg</property>
+    <center>
+        <x-m>0.0</x-m>
+        <y-m>0.0</y-m>
+        <z-m>0.0</z-m>
+    </center>
+    <axis>
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>1.0</z>
+    </axis>
+</animation>
+ 
+ <animation>
+    <type>pick</type>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <visible>true</visible>
+    <condition>
+        <and>
+            <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+        </and>
+    </condition>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>c182s.parajump(3);</script>
+        </binding>
+    </action>
+    <hovered>
+        <binding>
+            <command>set-tooltip</command>
+            <tooltip-id>pax1-jump</tooltip-id>
+            <label>Jump!</label>
+        </binding>
+    </hovered>
+ </animation>
 
 
 </PropertyList>

--- a/Models/Human/pax2.xml
+++ b/Models/Human/pax2.xml
@@ -189,5 +189,31 @@
   <z-offset>1.05</z-offset>
  </animation>
 
+ <animation>
+    <type>pick</type>
+    <object-name>male</object-name>
+    <object-name>female</object-name>
+    <visible>true</visible>
+    <condition>
+        <and>
+            <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+        </and>
+    </condition>
+    <action>
+        <button>0</button>
+        <repeatable>false</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>c182s.parajump(2);</script>
+        </binding>
+    </action>
+    <hovered>
+        <binding>
+            <command>set-tooltip</command>
+            <tooltip-id>pax2-jump</tooltip-id>
+            <label>Jump!</label>
+        </binding>
+    </hovered>
+ </animation>
 
 </PropertyList>

--- a/Models/c182-submodels.xml
+++ b/Models/c182-submodels.xml
@@ -1,0 +1,22 @@
+<PropertyList>
+    <submodel>
+        <name>parachutist</name>
+        <model>Models/Geometry/parachuter.xml</model>
+        <trigger>/sim/model/c182s/parachuters/trigger-jump</trigger>
+        <speed> 0 </speed>
+        <repeat> false </repeat>
+        <delay> 0 </delay>
+        <count> -1 </count>
+        <x-offset> -5 </x-offset>
+        <y-offset> 5 </y-offset>
+        <z-offset> -2 </z-offset>
+        <yaw-offset> 0 </yaw-offset>
+        <pitch-offset> 0 </pitch-offset>
+        <cd> 5 </cd>
+        <eda> 100 </eda>
+        <weight> 200 </weight>
+        <wind> true </wind>
+        <buoyancy> -100 </buoyancy>
+        <life> 600 </life>
+    </submodel>
+</PropertyList>

--- a/Models/c182s.xml
+++ b/Models/c182s.xml
@@ -197,8 +197,13 @@
             alias(rplayer.getNode("sim/multiplay/generic/bool[3]"));
         rplayer.getNode("pax/right-passenger/present", 1).
             alias(rplayer.getNode("sim/multiplay/generic/bool[4]"));
-        io.read_properties ("Aircraft/c182s/Models/Human/humans.xml", rplayer.getNode ("sim/model"));
-
+        rplayer.getNode("sim/model/c182s/parachuters/aircraft-mod-enabled", 1).
+            alias(rplayer.getNode("sim/multiplay/generic/bool[20]"));
+        setlistener(rplayer.getNode("sim/multiplay/generic/bool[20]").getPath(), func (node) {
+            var pax_modelcfg = node.getBoolValue()? "humans-pax-parachuters.xml" : "humans.xml";
+            io.read_properties ("Aircraft/c182s/Models/Human/"~pax_modelcfg, rplayer.getNode ("sim/model"));
+        }, 1, 0);
+        
 
         # Slow MP properties
         if (!defined("dual_control_tools")) {
@@ -1206,6 +1211,17 @@
 		</axis>
  </animation>
  
+<animation>
+    <type>select</type>
+    <object-name>Door.R</object-name>
+    <object-name>DoorHandle.R</object-name>
+    <object-name>WindowFrame.R</object-name>
+    <object-name>Window.R</object-name>
+    <object-name>Window.R.001</object-name>
+    <condition>
+        <not><property>sim/model/c182s/parachuters/aircraft-mod-enabled</property></not>
+    </condition>
+</animation>
 <animation>
    <type>pick</type>
    <object-name>Door.R</object-name>

--- a/Models/c182t.xml
+++ b/Models/c182t.xml
@@ -156,7 +156,12 @@
             alias(rplayer.getNode("sim/multiplay/generic/bool[3]"));
         rplayer.getNode("pax/right-passenger/present", 1).
             alias(rplayer.getNode("sim/multiplay/generic/bool[4]"));
-        io.read_properties ("Aircraft/c182s/Models/Human/humans.xml", rplayer.getNode ("sim/model"));
+        rplayer.getNode("sim/model/c182s/parachuters/aircraft-mod-enabled", 1).
+            alias(rplayer.getNode("sim/multiplay/generic/bool[20]"));
+        setlistener(rplayer.getNode("sim/multiplay/generic/bool[20]").getPath(), func (node) {
+            var pax_modelcfg = node.getBoolValue()? "humans-pax-parachuters.xml" : "humans.xml";
+            io.read_properties ("Aircraft/c182s/Models/Human/"~pax_modelcfg, rplayer.getNode ("sim/model"));
+        }, 1, 0);
 
 
         # Slow MP properties
@@ -1172,6 +1177,17 @@
 		</axis>
  </animation>
 
+ <animation>
+    <type>select</type>
+    <object-name>Door.R</object-name>
+    <object-name>DoorHandle.R</object-name>
+    <object-name>WindowFrame.R</object-name>
+    <object-name>Window.R</object-name>
+    <object-name>Window.R.001</object-name>
+    <condition>
+        <not><property>sim/model/c182s/parachuters/aircraft-mod-enabled</property></not>
+    </condition>
+</animation>
 <animation>
    <type>pick</type>
    <object-name>Door.R</object-name>

--- a/Models/interior-model-c182s.xml
+++ b/Models/interior-model-c182s.xml
@@ -182,7 +182,20 @@
 		</axis>
  </animation>
  
-  
+  <animation>
+    <type>select</type>
+    <object-name>Yoke.R</object-name>
+    <object-name>FrontSeat.R</object-name>
+    <object-name>RearSeats</object-name>
+    <object-name>IntDoor.R</object-name>
+    <object-name>FrameInt.R</object-name>
+    <object-name>doorhandleint_right</object-name>
+    <object-name>FrameLock1.R</object-name>
+    <object-name>FrameLock2.R</object-name>
+    <condition>
+        <not><property>sim/model/c182s/parachuters/aircraft-mod-enabled</property></not>
+    </condition>
+ </animation>
  <animation>
    <type>rotate</type>
 <object-name>IntDoor.R</object-name>
@@ -798,7 +811,6 @@
    <z>0.0</z>
   </axis>
  </animation>
- 
  
 <animation>
   <type>rotate</type>

--- a/Models/interior-model-c182t.xml
+++ b/Models/interior-model-c182t.xml
@@ -173,7 +173,20 @@
 		</axis>
  </animation>
  
-  
+ <animation>
+    <type>select</type>
+    <object-name>Yoke.R</object-name>
+    <object-name>FrontSeat.R</object-name>
+    <object-name>RearSeats</object-name>
+    <object-name>IntDoor.R</object-name>
+    <object-name>FrameInt.R</object-name>
+    <object-name>doorhandleint_right</object-name>
+    <object-name>FrameLock1.R</object-name>
+    <object-name>FrameLock2.R</object-name>
+    <condition>
+        <not><property>sim/model/c182s/parachuters/aircraft-mod-enabled</property></not>
+    </condition>
+ </animation>
  <animation>
    <type>rotate</type>
 <object-name>IntDoor.R</object-name>

--- a/Systems/cabin-heat_and_air.xml
+++ b/Systems/cabin-heat_and_air.xml
@@ -130,10 +130,16 @@
                 <max>1.0</max>
             </clipto>
         </summer>
+        
+        <pure_gain name="heat/door-right-removed"> <!-- right door removed -->
+            <input>/sim/model/c182s/parachuters/aircraft-mod-enabled</input>
+            <gain>2.0</gain>
+        </pure_gain>
 
         <summer name="heat/doors-windows-total">
             <input>heat/doors-windows-left</input>
             <input>heat/doors-windows-right</input>
+            <input>heat/door-right-removed</input>
             <input>heat/door-baggage</input>
         </summer>
 

--- a/Systems/sounds.xml
+++ b/Systems/sounds.xml
@@ -33,6 +33,7 @@
         <doors>
             <left>/sim/model/door-positions/DoorL/position-norm</left>
             <right>/sim/model/door-positions/DoorR/position-norm</right>
+            <right-removed>/sim/model/c182s/parachuters/aircraft-mod-enabled</right-removed>
         </doors>
         <windows>
             <left>/sim/model/door-positions/WindowL/position-norm</left>
@@ -86,6 +87,12 @@
                                                 <entry><ind>0.65</ind><dep>0.7</dep></entry>
                                                 <entry><ind>1.0</ind><dep>1.0</dep></entry>
                                             </table>
+                                            
+                                            <!-- Right door removed -->
+                                            <product>
+                                                <property alias="/params/doors/right-removed"/>
+                                                <value>1.4</value>
+                                            </product>
 
                                             <!-- Right window fully open is 1.0. Fully closed is 0.0 -->
                                             <table>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -311,12 +311,13 @@
       <bool n="2" alias="/sim/model/crew/pilot[1]/enabled"/>
       <bool n="3" alias="/sim/model/pax/pax[0]/enabled"/>
       <bool n="4" alias="/sim/model/pax/pax[1]/enabled"/>
+      <bool n="20" alias="/sim/model/c182s/parachuters/aircraft-mod-enabled"/>
       
 
     </generic>
   </multiplay>
 
-  <model include="Models/Human/humans.xml">
+  <model>
     <fallback-model-index>3</fallback-model-index>
    <path archive="y">Aircraft/c182s/Models/c182s.xml</path>
     <hide-yoke type="bool">false</hide-yoke>
@@ -446,6 +447,10 @@
           <ra-g type="double">0.025</ra-g>
           <ra-b type="double">0.025</ra-b>
       </lighting>
+      
+      <parachuters>
+          <aircraft-mod-enabled type="bool">false</aircraft-mod-enabled>
+      </parachuters>
     </c182s>
 
     <rendering>
@@ -1100,6 +1105,7 @@
             <path>/controls/SunVisor[1]/position-deg</path>
             <path>/sim/model/door-positions/DoorL/position-norm</path>
             <path>/sim/model/door-positions/DoorR/position-norm</path>
+            <path>/sim/model/c182s/parachuters/aircraft-mod-enabled</path>
             <path>/sim/model/door-positions/BaggageDoor/position-norm</path>
             <path>/sim/model/door-positions/WindowL/position-norm</path>
             <path>/sim/model/door-positions/WindowR/position-norm</path>
@@ -1130,6 +1136,11 @@
         </aircraft-data>
 
      <flight-recorder include="Systems/flight-recorder/flight-recorder.xml"/>
+     
+     <submodels>
+        <serviceable type="bool">true</serviceable>
+        <path>Models/c182-submodels.xml</path>
+     </submodels>
 
  </sim>
 

--- a/c182s-sound.xml
+++ b/c182s-sound.xml
@@ -725,6 +725,10 @@
                 <property>/sim/model/c182s/sound/volume-boost-right-door</property>
             </volume>
             <volume>
+                <factor>3.0</factor>
+                <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+            </volume>
+            <volume>
                 <offset>-0.03</offset>
             </volume>
             <pitch>

--- a/c182s.xml
+++ b/c182s.xml
@@ -1463,6 +1463,15 @@
                     <value>0.0150</value>
                 </product>
             </function>
+            <function name="aero/coefficient/CDdoorR-removed">
+                <description>Drag_due_to_door-r-removed</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+                    <value>0.020</value>
+                </product>
+            </function>
             <function name="aero/coefficient/CDbaggagedoor">
                 <description>Drag_due_to_door_left</description>
                 <product>
@@ -2121,6 +2130,20 @@
                 <z>0.0</z>
             </direction>
         </force>
+        
+        <force name="parachuterOnStrut" frame="BODY" unit="LBS" >
+            <location unit="M">
+                <x> 0.794</x>
+                <y> 2.2</y>
+                <z> 0.0</z>
+            </location>
+            <direction>
+                <x>-1.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+            </direction>
+        </force>
+        
     </external_reactions>
     
     <system file="c182s-stallhorn"/>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -279,11 +279,12 @@
       <bool n="2" alias="/sim/model/crew/pilot[1]/enabled"/>
       <bool n="3" alias="/sim/model/pax/pax[0]/enabled"/>
       <bool n="4" alias="/sim/model/pax/pax[1]/enabled"/>
+      <bool n="20" alias="/sim/model/c182s/parachuters/aircraft-mod-enabled"/>
 
     </generic>
   </multiplay>
 
-  <model include="Models/Human/humans.xml">
+  <model>
    <path archive="y">Aircraft/c182s/Models/c182t.xml</path>
    <fallback-model-index>3</fallback-model-index>
    <hide-yoke type="bool">false</hide-yoke>
@@ -415,6 +416,11 @@
           <ra-g type="double">0.025</ra-g>
           <ra-b type="double">0.025</ra-b>
       </lighting>
+      
+      <parachuters>
+          <aircraft-mod-enabled type="bool">false</aircraft-mod-enabled>
+      </parachuters>
+        
     </c182s>
 
     <rendering>
@@ -1000,6 +1006,7 @@
             <path>/controls/SunVisor[1]/position-deg</path>
             <path>/sim/model/door-positions/DoorL/position-norm</path>
             <path>/sim/model/door-positions/DoorR/position-norm</path>
+            <path>/sim/model/c182s/parachuters/aircraft-mod-enabled</path>
             <path>/sim/model/door-positions/BaggageDoor/position-norm</path>
             <path>/sim/model/door-positions/WindowL/position-norm</path>
             <path>/sim/model/door-positions/WindowR/position-norm</path>

--- a/c182t.xml
+++ b/c182t.xml
@@ -1464,6 +1464,15 @@
                     <value>0.0150</value>
                 </product>
             </function>
+            <function name="aero/coefficient/CDdoorR-removed">
+                <description>Drag_due_to_door-r-removed</description>
+                <product>
+                    <property>aero/qbar-psf</property>
+                    <property>metrics/Sw-sqft</property>
+                    <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+                    <value>0.020</value>
+                </product>
+            </function>
             <function name="aero/coefficient/CDbaggagedoor">
                 <description>Drag_due_to_door_left</description>
                 <product>
@@ -2122,6 +2131,20 @@
                 <z>0.0</z>
             </direction>
         </force>
+        
+        <force name="parachuterOnStrut" frame="BODY" unit="LBS" >
+            <location unit="M">
+                <x> 0.794</x>
+                <y> 2.2</y>
+                <z> 0.0</z>
+            </location>
+            <direction>
+                <x>-1.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+            </direction>
+        </force>
+        
     </external_reactions>
     
     <system file="c182s-stallhorn"/>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -322,6 +322,55 @@
             </binding>
         </checkbox>
         
+        <group>
+            <layout>hbox</layout>
+            <checkbox>
+                <halign>left</halign>
+                <label>Parachuter mod</label>
+                <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+                <live>true</live>
+                <enable>
+                    <and>
+                        <less-than>
+                            <property>velocities/groundspeed-kt</property>
+                            <value>0.1</value>
+                        </less-than>
+                    </and>
+                </enable>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+                <binding>
+                    <command>property-assign</command>
+                    <property>sim/model/door-positions/DoorR/position-norm</property>
+                    <value>0</value>
+                </binding>
+            </checkbox>
+            <button>
+                <enable>
+                    <and>
+                        <property>/sim/model/c182s/parachuters/aircraft-mod-enabled</property>
+                        <not><property>/sim/model/c182s/parachuters/trigger-running</property></not>
+                        <or>
+                            <property>sim/model/crew/pilot[1]/enabled</property>
+                            <property>/sim/model/pax/pax[0]/enabled</property>
+                            <property>/sim/model/pax/pax[1]/enabled</property>
+                        </or>
+                    </and>
+                </enable>
+                <legend>Jump!</legend>
+                <binding>
+                    <command>nasal</command>
+                    <script>
+                        c182s.parajump_all();
+                    </script>
+                </binding>
+                <binding>
+                    <command>dialog-close</command>
+                </binding>
+            </button>
+        </group>
+        
 <hrule/>
 
         <group>


### PR DESCRIPTION
With the option enabled, seats, right door and yoke are removed.
When clicking on the passengers, they will jump out.
Alternatively all can be dropped at once using the "Jump!" button
from the aircraft options menu.

Fix #440