### PR TITLE
Better oil pressure simulation

### DIFF
--- a/Engines/engIO540AB1A5.xml
+++ b/Engines/engIO540AB1A5.xml
@@ -36,5 +36,5 @@
     <oil-pressure-relief-valve-psi> 67 </oil-pressure-relief-valve-psi> <!-- lycoming manual states: min=55; max=95; idle=25; start&warm-up=115 -->
     <oil-pressure-rpm-max>          1000  </oil-pressure-rpm-max>
     <design-oil-temp-degK>           358  </design-oil-temp-degK>     <!-- level cruise: between 165degF and 200 degF -->
-    <!--<oil-viscosity-index>              0.25 </oil-viscosity-index> --> <!-- TODO: .25 default jsbsim value -->
+    <!--<oil-viscosity-index>              0.25 </oil-viscosity-index> --> <!-- TODO: .25 default jsbsim value, but simulated in engine.xml -->
 </piston_engine>

--- a/Nasal/c182t-EISPublisher.nas
+++ b/Nasal/c182t-EISPublisher.nas
@@ -37,7 +37,7 @@ var GenericEISPublisher =
     obj.addPropMap("OilPressurePSI", "/engines/engine[0]/indicated-oil-pressure-psi");
     obj.addPropMap("OilTemperatureF", "/engines/engine/indicated-oil-final-temperature-degf");
     obj.addPropMap("EGTNorm", "/engines/engine[0]/egt-norm");
-    obj.addPropMap("CHTDegF", "/engines/engine[0]/cht-degf");
+    obj.addPropMap("CHTDegF", "/engines/engine[0]/indicated-cht-degf");
     obj.addPropMap("VacuumSuctionInHG", "/systems/vacuum/suction-inhg");
 
     return obj;

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -540,6 +540,35 @@
     </flipflop>
     
     
+    <!-- Oil kinematic viscosity -->
+    <filter>
+        <name>Oil kinematic viscosity</name>
+        <type>gain</type>
+        <input>
+            <!-- TODO: in the future we might switch the inputs based on a selected oil grade.
+                       POH 8-14 says, we can use 15W-50 or 20W-50 in all temps -->
+            <!-- Table for 15W-40 https://wiki.anton-paar.com/us-en/engine-oil/; (adjusted for degC->degF) -->
+            <expression>
+                <table>
+                    <property>/engines/engine/oil-final-temperature-degf</property>
+                    <entry><ind>32</ind><dep>1489.4</dep></entry>  <!-- 0°C -->
+                    <entry><ind>50</ind><dep>658.60</dep></entry>
+                    <entry><ind>68</ind><dep>326.87</dep></entry>
+                    <entry><ind>86</ind><dep>178.01</dep></entry>   <!-- 30°C -->
+                    <entry><ind>104</ind><dep>105.10</dep></entry>  <!-- 40°C, start of green arc -->
+                    <entry><ind>122</ind><dep>66.464</dep></entry>
+                    <entry><ind>140</ind><dep>44.585</dep></entry>
+                    <entry><ind>158</ind><dep>31.350</dep></entry>
+                    <entry><ind>176</ind><dep>23.006</dep></entry>
+                    <entry><ind>194</ind><dep>17.467</dep></entry>
+                    <entry><ind>212</ind><dep>13.648</dep></entry>  <!-- 100°C -->
+                </table>
+            </expression>
+        </input>
+        <output>
+            <property>/engines/engine[0]/oil-kinematic-viscosity</property>
+        </output>
+    </filter>
     
     
     <!-- Oil temperature -->

--- a/Systems/external-heat.xml
+++ b/Systems/external-heat.xml
@@ -42,15 +42,6 @@ Author: 12/2017  Benedikt Hallinger
             </range>
             <output>/engines/engine/external-heat/applied-degF</output>
         </aerosurface_scale>
-        <fcs_function name="Oil temp plus external heat">
-            <function>
-                <sum>
-                    <property>/engines/engine/external-heat/applied-degF</property>
-                    <property>/engines/engine/oil-temperature-degf-indicated</property> <!-- compensated for env-temp and low oil, see engine.xml -->
-                </sum>
-            </function>
-            <output>/engines/engine/oil-final-temperature-degf</output>   
-        </fcs_function>
         
         <!-- todo: could be modelled more realistical, since engine radiation should also have a little effect -->
         <fcs_function name="Cowling environment air Temperature">
@@ -63,18 +54,6 @@ Author: 12/2017  Benedikt Hallinger
             <output>/engines/engine/cowling-air-temperature-degf</output>   
         </fcs_function>
         
-        <!-- todo: should be better placed in engine.xml, but is not active there... -->
-        <summer name="Engine Oil compensated environment Temperature">
-            <input>/engines/engine/oil-temperature-degf</input>
-            <input>-/engines/engine/oil-temperature-env-diff</input>
-            <output>/engines/engine/oil-compensated-temperature-degf</output>
-        </summer>
-        <summer name="CHT compensated environment Temperature">
-            <input>/engines/engine/cht-degf</input>
-            <input>-/engines/engine/cht-temperature-env-diff</input>
-            <input>/engines/engine/external-heat/applied-degF</input>
-            <output>/engines/engine/cht-compensated-temperature-degf</output>
-        </summer>
     </channel>
 
 </system>

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -88,10 +88,53 @@
         </output>
     </filter>
 
+
+    <filter>
+        <name>Engine Indicated Oil Pressure needle speed</name>
+        <type>gain</type>
+        <input>
+            <!-- adjust needle quickly at startup, for the case that engine starts with engine on from state system -->
+            <condition>
+                <less-than>
+                    <property>/sim/time/elapsed-sec</property>
+                    <value>5.0</value>
+                </less-than>
+            </condition>
+            <value>0.1</value>
+        </input>
+        <input>
+            <condition>
+                <property>/instruments/oil-press/serviceable</property>
+                <greater-than>
+                    <property>/systems/electrical/outputs/instr-ignition-switch</property>
+                    <value>12.0</value>
+                </greater-than>
+                <greater-than>
+                    <property>/engines/engine/oil-pressure-psi</property>
+                    <value>5.0</value>
+                </greater-than>
+            </condition>
+            <expression>
+                <!-- high viscosity (ie. cold) oil is more slowly building pressure -->
+                <table>
+                    <property>/engines/engine[0]/oil-kinematic-viscosity</property>
+                    <entry><ind>  30  </ind> <dep>   1 </dep></entry>
+                    <entry><ind>  150 </ind> <dep>  10 </dep></entry>
+                    <entry><ind> 1500 </ind> <dep>  60 </dep></entry>
+                </table>
+            </expression>
+        </input>
+        <input>
+            <value>1.0</value>
+        </input>
+        <output>
+            <property>/instruments/oil-press/filter-time</property>
+        </output>
+    </filter>
     <filter>
         <name>Engine Indicated Oil Pressure</name>
         <type>exponential</type>
-        <filter-time>1.0</filter-time>
+        <filter-time><property>/instruments/oil-press/filter-time</property></filter-time>
         <input>
             <condition>
                 <property>/instruments/oil-press/serviceable</property>

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -187,7 +187,8 @@
                     <value>12.0</value>
                 </greater-than>
             </condition>
-            <property>/engines/engine/cht-degf</property>
+            <!--<property>/engines/engine/cht-degf</property>-->
+            <property>/engines/engine/cht-final-temperature-degf</property>
         </input>
         <input>
             <value>0.0</value>

--- a/Systems/propulsion.xml
+++ b/Systems/propulsion.xml
@@ -155,6 +155,35 @@
 	
     </channel>
 
+
+<channel name="Engine temperature">
+    <summer name="Engine Oil compensated environment Temperature">
+        <input>/engines/engine/oil-temperature-degf</input>
+        <input>-/engines/engine/oil-temperature-env-diff</input>
+        <input>/engines/engine/oil-temperature-degf-offset</input>  <!-- to give some warm oil with engine running states at sim start (takeoff, cruise), see c182s-states.nas -->
+        <output>/engines/engine/oil-compensated-temperature-degf</output>
+    </summer>
+    <summer name="CHT compensated environment Temperature">
+        <input>/engines/engine/cht-degf</input>
+        <input>-/engines/engine/cht-temperature-env-diff</input>
+        <input>/engines/engine/cht-temperature-degf-offset</input>   <!-- to give some warm cylinder with engine running states at sim start (takeoff, cruise), see c182s-states.nas -->
+        <output>/engines/engine/cht-compensated-temperature-degf</output>
+    </summer>
+    
+    <summer name="Oil temp plus external heat">
+        <input>/engines/engine/oil-temperature-degf-indicated</input>
+        <input>/engines/engine/external-heat/applied-degF</input>
+        <output>/engines/engine/oil-final-temperature-degf</output>
+    </summer>
+
+    <summer name="CHT temp plus external heat">
+        <input>/engines/engine/cht-compensated-temperature-degf</input>
+        <input>/engines/engine/external-heat/applied-degF</input>
+        <output>/engines/engine/cht-final-temperature-degf</output>
+    </summer>
+</channel>
+
+
 <channel name= "Prop Icing">
 <fcs_function name="systems/propulsion/prop-ice">
           <function>
@@ -707,12 +736,6 @@
                 <product>
                     <property>/engines/engine/complex-engine-procedures</property>  <!-- complex-engine-procedures EQ 1 -->
                     <property>/engines/engine/allow-oil-management</property>       <!-- allow-oil-management EQ 1 -->
-                    <abs> <!-- oil-temp-override EQ 0; esp. for autostart -->
-                        <difference>
-                            <property>/sim/start-state-internal/oil-temp-override</property>
-                            <value> 1 </value>
-                        </difference>
-                    </abs>
                     <!--<property>/engines/engine/running</property>--> <!-- only apply with pistons moving -->
                 
                     <table>

--- a/Tutorials/sparkPlugFouling.xml
+++ b/Tutorials/sparkPlugFouling.xml
@@ -230,7 +230,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
     <step>
         <condition>
             <greater-than-equals>
-                <property>/engines/engine/cht-degf</property>
+                <property>/engines/engine/cht-final-temperature-degf</property>
                 <value>300</value>
             </greater-than-equals>
         </condition>
@@ -253,7 +253,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
     <step>
         <condition>
             <greater-than-equals>
-                <property>/engines/engine/cht-degf</property>
+                <property>/engines/engine/cht-final-temperature-degf</property>
                 <value>300</value>
             </greater-than-equals>
         </condition>
@@ -261,7 +261,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>300</value>
                 </greater-than-equals>
             </condition>
@@ -327,7 +327,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>500</value>
                 </greater-than-equals>
             </condition>
@@ -396,7 +396,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>500</value>
                 </greater-than-equals>
             </condition>
@@ -471,7 +471,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>500</value>
                 </greater-than-equals>
             </condition>
@@ -510,7 +510,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>500</value>
                 </greater-than-equals>
             </condition>
@@ -534,7 +534,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>500</value>
                 </greater-than-equals>
             </condition>
@@ -559,7 +559,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>500</value>
                 </greater-than-equals>
             </condition>
@@ -585,7 +585,7 @@ In cruise, the problem should resolve within one or two minutes when properly le
         <error>
             <condition>
                 <greater-than-equals>
-                    <property>/engines/engine/cht-degf</property>
+                    <property>/engines/engine/cht-final-temperature-degf</property>
                     <value>500</value>
                 </greater-than-equals>
             </condition>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -225,9 +225,6 @@
 
   <!-- Aircraft states -->
   <start-state type="string">auto</start-state>
-  <start-state-internal>
-      <oil-temp-override type="bool">false</oil-temp-override>
-  </start-state-internal>
 
   <chocks>
   <enable type="bool">false</enable>
@@ -1296,6 +1293,8 @@
    <allow-oil-management type="bool">false</allow-oil-management>
    <winter-kit-installed type="bool">false</winter-kit-installed>
    <oil-temperature-env-diff type="double">0</oil-temperature-env-diff>
+   <oil-temperature-degf-offset type="double">0</oil-temperature-degf-offset>
+   <cht-temperature-degf-offset type="double">0</cht-temperature-degf-offset>
    <allow-sparkplug-icing type="bool">false</allow-sparkplug-icing>
    <oil-compensated-temperature-degf type="double">60</oil-compensated-temperature-degf>
    <external-heat>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -207,9 +207,6 @@
 
   <!-- Aircraft states -->
   <start-state type="string">auto</start-state>
-  <start-state-internal>
-      <oil-temp-override type="bool">false</oil-temp-override>
-  </start-state-internal>
 
   <chocks>
   <enable type="bool">false</enable>
@@ -1196,6 +1193,8 @@
    <allow-sparkplug-icing type="bool">false</allow-sparkplug-icing>
    <winter-kit-installed type="bool">false</winter-kit-installed>
    <oil-temperature-env-diff type="double">0</oil-temperature-env-diff>
+   <oil-temperature-degf-offset type="double">0</oil-temperature-degf-offset>
+   <cht-temperature-degf-offset type="double">0</cht-temperature-degf-offset>
    <oil-compensated-temperature-degf type="double">60</oil-compensated-temperature-degf>
    <external-heat>
        <enabled type="bool">false</enabled>


### PR DESCRIPTION
Cold oil will now more slowly build pressure.

- oil pressure depending on viscosity
- viscosity depending on oil grade and oil temp

:point_up: Potentially can support switching oil grades in the future! :)

---
**Sources**
- POH 4-21:
  ![grafik](https://user-images.githubusercontent.com/13608602/144278715-4a750163-04b6-4589-bf76-e9b4bb987ad6.png)

- POH 8-14:
  ![grafik](https://user-images.githubusercontent.com/13608602/144279023-973573e7-7139-4b11-8966-3eceeb9e8b66.png)

- 15W-50 viscosity specs: https://www.mobil.com/en-us/passenger-v ... il-1-15w50

- 15W-40 viscosity courve: https://wiki.anton-paar.com/us-en/engine-oil/

- some real life reports suggesting the current simulation is somewhat realistic (takes some time (minutes in very cold weather) where the needle moves slowly): http://www.cessna172club.com/forum/ubbthreads.php?ubb=showflat&Number=102858