### PR TITLE
Add pedestal light as compositor light spot.

### DIFF
--- a/Models/c182s.xml
+++ b/Models/c182s.xml
@@ -33,6 +33,9 @@
         # Note: This nasal code is loaded just for remote multiplayer models
 
         var rplayer = cmdarg();
+        
+        # mark model as remote
+        rplayer.getNode("sim/model/c182s/remote-instance", 1).setBoolValue(1);
 
         # Set up property aliases for animations.
         rplayer.getNode("sim/model/door-positions/DoorL/position-norm-effective", 1).
@@ -2602,6 +2605,20 @@
   <range-m>6</range-m>
 </light>
  
+ <animation>
+    <type>select</type>
+    <object-name>pedestal-spot</object-name>
+    <condition>
+        <and>
+            <greater-than>
+                <property>/systems/electrical/outputs/pedestal-lights-norm</property>
+                <value>0</value>
+            </greater-than>
+            <property>sim/current-view/internal</property>
+            <not> <property>sim/model/c182s/remote-instance</property>  </not>
+        </and>
+    </condition>
+ </animation>
  <light>
   <name>pedestal-spot</name>
   <type>spot</type>
@@ -2640,7 +2657,7 @@
   </attenuation>
   <spot-exponent>3.5</spot-exponent>
   <spot-cutoff>30</spot-cutoff>
-  <range-m>0.05</range-m>
+  <range-m>0.07</range-m>
   <dim-factor>
     <expression>
         <min>

--- a/Models/c182s.xml
+++ b/Models/c182s.xml
@@ -2602,7 +2602,68 @@
   <range-m>6</range-m>
 </light>
  
- 
+ <light>
+  <name>pedestal-spot</name>
+  <type>spot</type>
+  <position>
+    <x-m>0.3587</x-m>
+    <y-m>-0.0380</y-m>
+    <z-m>0.0107</z-m>
+  </position>
+  <direction>
+    <pitch-deg>-12.45</pitch-deg>
+    <roll-deg>4</roll-deg>
+    <heading-deg>0</heading-deg>
+  </direction>
+  <ambient>
+    <r>0.03</r>
+    <g>0.03</g>
+    <b>0.03</b>
+    <a>1</a>
+  </ambient>
+  <diffuse>
+    <r>0.95</r>
+    <g>0.9</g>
+    <b>0.9</b>
+    <a>1</a>
+  </diffuse>
+  <specular>
+    <r>0.95</r>
+    <g>0.9</g>
+    <b>0.9</b>
+    <a>1</a>
+  </specular>
+  <attenuation>
+    <c>1.0</c>
+    <l>0.07</l>
+    <q>1.3</q>
+  </attenuation>
+  <spot-exponent>3.5</spot-exponent>
+  <spot-cutoff>30</spot-cutoff>
+  <range-m>0.05</range-m>
+  <dim-factor>
+    <expression>
+        <min>
+            <value>1</value>
+            <sum>
+                <product>
+                    <value>0.5</value>
+                    <property>/systems/electrical/outputs/glareshield-lights-norm</property>
+                </product>
+                <property>/systems/electrical/outputs/pedestal-lights-norm</property>
+                <product>
+                    <value>0.20</value>
+                    <property>/systems/electrical/outputs/dome-light-r</property>
+                </product>
+                <product>
+                    <value>0.20</value>
+                    <property>/systems/electrical/outputs/dome-light-l</property>
+                </product>
+            </sum>
+        </min>
+    </expression>
+  </dim-factor>
+</light>
  
 <model>
 <condition>

--- a/Models/c182t.xml
+++ b/Models/c182t.xml
@@ -2568,6 +2568,68 @@
   <range-m>6</range-m>
 </light>
  
+<light>
+  <name>pedestal-spot</name>
+  <type>spot</type>
+  <position>
+    <x-m>0.3587</x-m>
+    <y-m>-0.0380</y-m>
+    <z-m>0.0107</z-m>
+  </position>
+  <direction>
+    <pitch-deg>-12.45</pitch-deg>
+    <roll-deg>4</roll-deg>
+    <heading-deg>0</heading-deg>
+  </direction>
+  <ambient>
+    <r>0.03</r>
+    <g>0.03</g>
+    <b>0.03</b>
+    <a>1</a>
+  </ambient>
+  <diffuse>
+    <r>0.95</r>
+    <g>0.9</g>
+    <b>0.9</b>
+    <a>1</a>
+  </diffuse>
+  <specular>
+    <r>0.95</r>
+    <g>0.9</g>
+    <b>0.9</b>
+    <a>1</a>
+  </specular>
+  <attenuation>
+    <c>1.0</c>
+    <l>0.07</l>
+    <q>1.3</q>
+  </attenuation>
+  <spot-exponent>3.5</spot-exponent>
+  <spot-cutoff>30</spot-cutoff>
+  <range-m>0.05</range-m>
+  <dim-factor>
+    <expression>
+        <min>
+            <value>1</value>
+            <sum>
+                <product>
+                    <value>0.5</value>
+                    <property>/systems/electrical/outputs/glareshield-lights-norm</property>
+                </product>
+                <property>/systems/electrical/outputs/pedestal-lights-norm</property>
+                <product>
+                    <value>0.20</value>
+                    <property>/systems/electrical/outputs/dome-light-r</property>
+                </product>
+                <product>
+                    <value>0.20</value>
+                    <property>/systems/electrical/outputs/dome-light-l</property>
+                </product>
+            </sum>
+        </min>
+    </expression>
+  </dim-factor>
+</light>
  
  
 <model>

--- a/Models/c182t.xml
+++ b/Models/c182t.xml
@@ -33,6 +33,9 @@
         # Note: This nasal code is loaded just for remote multiplayer models
 
         var rplayer = cmdarg();
+        
+        # mark model as remote
+        rplayer.getNode("sim/model/c182s/remote-instance", 1).setBoolValue(1);
 
         # Set up property aliases for animations.
         rplayer.getNode("sim/model/door-positions/DoorL/position-norm-effective", 1).
@@ -2567,7 +2570,21 @@
   <spot-cutoff>89</spot-cutoff>
   <range-m>6</range-m>
 </light>
- 
+
+<animation>
+    <type>select</type>
+    <object-name>pedestal-spot</object-name>
+    <condition>
+        <and>
+            <greater-than>
+                <property>/systems/electrical/outputs/pedestal-lights-norm</property>
+                <value>0</value>
+            </greater-than>
+            <property>sim/current-view/internal</property>
+            <not> <property>sim/model/c182s/remote-instance</property>  </not>
+        </and>
+    </condition>
+</animation>
 <light>
   <name>pedestal-spot</name>
   <type>spot</type>
@@ -2606,7 +2623,7 @@
   </attenuation>
   <spot-exponent>3.5</spot-exponent>
   <spot-cutoff>30</spot-cutoff>
-  <range-m>0.05</range-m>
+  <range-m>0.07</range-m>
   <dim-factor>
     <expression>
         <min>


### PR DESCRIPTION
This way the trim wheel is lit and can be seen in the dark
The light is controlled mainly by the pedestal light knob but also affected by the glareshield and dome lights.

Fix #476