### PR TITLE
Fixes/tewaks for radio stack / instrument lighting

### DIFF
--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -221,7 +221,7 @@
                 <sum>
                     <property>/sim/model/c182s/lighting/audio-panel</property>
                     <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
+                    <property>/sim/model/c182s/lighting/nav-1</property> <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
                 </sum>
             </expression>
         </input>
@@ -244,7 +244,7 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <property>/sim/model/c182s/lighting/nav-2</property> <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
                     <property>/sim/model/c182s/lighting/ident</property>
                 </sum>
@@ -267,12 +267,12 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/audio-panel</property>
-                    <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <!--<property>/sim/model/c182s/lighting/audio-panel</property>  no light from audio panel -->
+                    <!--<property>/sim/model/c182s/lighting/dme</property>  no light for DME -->
+                    <property>/sim/model/c182s/lighting/nav-1</property> <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
+                    <property>/sim/model/c182s/lighting/nav-2</property> <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
-                    <property>/sim/model/c182s/lighting/ident</property>
+                    <!--<property>/sim/model/c182s/lighting/ident</property>  no light for transponder -->
                 </sum>
             </expression>
         </input>
@@ -356,12 +356,12 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/audio-panel-norm</property>
-                    <property>/sim/model/c182s/lighting/dme-norm</property>
-                    <property>/sim/model/c182s/lighting/nav-1-norm</property>
-                    <property>/sim/model/c182s/lighting/nav-2-norm</property>
-                    <property>/sim/model/c182s/lighting/adf-norm</property>
-                    <property>/sim/model/c182s/lighting/ident-norm</property>
+                    <!--<property>/sim/model/c182s/lighting/audio-panel</property>  no light from audio panel -->
+                    <!--<property>/sim/model/c182s/lighting/dme</property>  no light for DME -->
+                    <property>/sim/model/c182s/lighting/nav-1</property> <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
+                    <property>/sim/model/c182s/lighting/nav-2</property> <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
+                    <property>/sim/model/c182s/lighting/adf</property>
+                    <!--<property>/sim/model/c182s/lighting/ident</property>  no light for transponder -->
                 </sum>
             </expression>
         </input>
@@ -386,7 +386,7 @@
                 <sum>
                     <property>/sim/model/c182s/lighting/audio-panel</property>
                     <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
+                    <property>/sim/model/c182s/lighting/nav-1</property>  <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
                 </sum>
             </expression>
         </input>
@@ -409,7 +409,7 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <property>/sim/model/c182s/lighting/nav-2</property>  <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
                     <property>/sim/model/c182s/lighting/ident</property>
                 </sum>
@@ -457,7 +457,7 @@
                 <sum>
                     <property>/sim/model/c182s/lighting/audio-panel</property>
                     <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
+                    <property>/sim/model/c182s/lighting/nav-1</property>  <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
                 </sum>
             </expression>
         </input>
@@ -480,7 +480,7 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <property>/sim/model/c182s/lighting/nav-2</property>  <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
                     <property>/sim/model/c182s/lighting/ident</property>
                 </sum>
@@ -503,12 +503,12 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/audio-panel</property>
-                    <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <!--<property>/sim/model/c182s/lighting/audio-panel</property>  no light from audio panel -->
+                    <!--<property>/sim/model/c182s/lighting/dme</property>  no light for DME -->
+                    <property>/sim/model/c182s/lighting/nav-1</property> <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
+                    <property>/sim/model/c182s/lighting/nav-2</property> <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
-                    <property>/sim/model/c182s/lighting/ident</property>
+                    <!--<property>/sim/model/c182s/lighting/ident</property>  no light for transponder -->
                 </sum>
             </expression>
         </input>
@@ -622,7 +622,7 @@
                 <sum>
                     <property>/sim/model/c182s/lighting/audio-panel</property>
                     <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
+                    <property>/sim/model/c182s/lighting/nav-1</property>  <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
                 </sum>
             </expression>
         </input>
@@ -645,7 +645,7 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <property>/sim/model/c182s/lighting/nav-2</property>  <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
                     <property>/sim/model/c182s/lighting/ident</property>
                 </sum>
@@ -693,7 +693,7 @@
                 <sum>
                     <property>/sim/model/c182s/lighting/audio-panel</property>
                     <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
+                    <property>/sim/model/c182s/lighting/nav-1</property>  <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
                 </sum>
             </expression>
         </input>
@@ -716,7 +716,7 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <property>/sim/model/c182s/lighting/nav-2</property>  <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
                     <property>/sim/model/c182s/lighting/ident</property>
                 </sum>
@@ -739,12 +739,12 @@
             </condition>
             <expression>
                 <sum>
-                    <property>/sim/model/c182s/lighting/audio-panel</property>
-                    <property>/sim/model/c182s/lighting/dme</property>
-                    <property>/sim/model/c182s/lighting/nav-1</property>
-                    <property>/sim/model/c182s/lighting/nav-2</property>
+                    <!--<property>/sim/model/c182s/lighting/audio-panel</property>  no light from audio panel -->
+                    <!--<property>/sim/model/c182s/lighting/dme</property>  no light for DME -->
+                    <property>/sim/model/c182s/lighting/nav-1</property> <property>/sim/model/c182s/lighting/nav-1</property>  <!-- counted twice because of com+nav unit -->
+                    <property>/sim/model/c182s/lighting/nav-2</property> <property>/sim/model/c182s/lighting/nav-2</property>  <!-- counted twice because of com+nav unit -->
                     <property>/sim/model/c182s/lighting/adf</property>
-                    <property>/sim/model/c182s/lighting/ident</property>
+                    <!--<property>/sim/model/c182s/lighting/ident</property>  no light for transponder -->
                 </sum>
             </expression>
         </input>
@@ -754,15 +754,33 @@
     </filter>
 
     <!-- Reduce the red glow from the digits of the radio stack
-         if the instrument lighting is at 100 %.
+         if the instrument lighting or glareshield is really bright.
     -->
+    <filter>
+        <name>Inst/Glareshield lighting</name>
+        <type>gain</type>
+        <input>
+            <expression>
+                <max>
+                    <product>
+                        <property>/sim/model/c182s/lighting/glare-ra-gain</property>
+                        <property>/systems/electrical/outputs/glareshield-lights-norm</property>
+                    </product>
+                    <property>/systems/electrical/outputs/instrument-lights-norm</property>
+                </max>
+            </expression>
+        </input>
+        <output>
+            <property>/sim/model/c182s/lighting/inst-gain-panellights</property>
+        </output>
+    </filter>
     <filter>
         <name>Inst Gain As Function Of Instrument Lighting</name>
         <type>gain</type>
         <input>
             <expression>
                 <table>
-                    <property>/systems/electrical/outputs/instrument-lights-norm</property>
+                    <property>/sim/model/c182s/lighting/inst-gain-panellights</property>
                     <entry><ind>0.0</ind><dep>2.5</dep></entry>
                     <entry><ind>1.0</ind><dep>0.4</dep></entry>
                 </table>
@@ -770,6 +788,20 @@
         </input>
         <output>
             <property>/sim/model/c182s/lighting/inst-gain</property>
+        </output>
+    </filter>
+    
+    <filter>
+        <name>Inst radiance</name>
+        <type>gain</type>
+        <gain>
+            <property>/sim/model/c182s/lighting/inst-ra-gain</property>
+        </gain>
+        <input>
+            <property>/systems/electrical/outputs/instrument-lights-norm</property>
+        </input>
+        <output>
+            <property>/sim/model/c182s/lighting/inst-ra</property>
         </output>
     </filter>
 
@@ -793,7 +825,7 @@
         <input>
             <expression>
                 <sum>
-                    <property>/systems/electrical/outputs/instrument-lights-norm</property>
+                    <property>/sim/model/c182s/lighting/inst-ra</property>
                     <property>/sim/model/c182s/lighting/rad-r-total</property>
                 </sum>
             </expression>
@@ -837,7 +869,7 @@
         <input>
             <expression>
                 <sum>
-                    <property>/systems/electrical/outputs/instrument-lights-norm</property>
+                    <property>/sim/model/c182s/lighting/inst-ra</property>
                     <property>/sim/model/c182s/lighting/rad-g-total</property>
                 </sum>
             </expression>
@@ -881,7 +913,7 @@
         <input>
             <expression>
                 <sum>
-                    <property>/systems/electrical/outputs/instrument-lights-norm</property>
+                    <property>/sim/model/c182s/lighting/inst-ra</property>
                     <property>/sim/model/c182s/lighting/rad-b-total</property>
                 </sum>
             </expression>

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -266,7 +266,7 @@
       <input>
         <condition>
           <greater-than>
-              <property>/instrumentation/nav[0]/volume</property>
+              <property>/instrumentation/comm[0]/power-btn</property>
               <value>0.0</value>
             </greater-than>
         </condition>
@@ -286,7 +286,7 @@
       <input>
         <condition>
           <greater-than>
-              <property>/instrumentation/nav[1]/volume</property>
+              <property>/instrumentation/comm[1]/power-btn</property>
               <value>0.0</value>
             </greater-than>
         </condition>
@@ -386,7 +386,7 @@
       <input>
         <condition>
           <greater-than>
-              <property>/instrumentation/nav[0]/volume</property>
+              <property>/instrumentation/nav[0]/power-btn</property>
               <value>0.0</value>
             </greater-than>
         </condition>
@@ -406,7 +406,7 @@
       <input>
         <condition>
           <greater-than>
-              <property>/instrumentation/nav[1]/volume</property>
+              <property>/instrumentation/nav[1]/power-btn</property>
               <value>0.0</value>
             </greater-than>
         </condition>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -442,9 +442,11 @@
                 <immat-on-panel>true</immat-on-panel>
 
       <lighting>
-          <ra-r type="double">0.05</ra-r>
-          <ra-g type="double">0.025</ra-g>
-          <ra-b type="double">0.025</ra-b>
+          <ra-r type="double">0.095</ra-r>
+          <ra-g type="double">0.065</ra-g>
+          <ra-b type="double">0.065</ra-b>
+          <inst-ra-gain type="double">1.15</inst-ra-gain>
+          <glare-ra-gain type="double">0.5</glare-ra-gain>
       </lighting>
       
       <parachuters>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -442,10 +442,10 @@
                 <immat-on-panel>true</immat-on-panel>
 
       <lighting>
-          <ra-r type="double">0.095</ra-r>
-          <ra-g type="double">0.065</ra-g>
-          <ra-b type="double">0.065</ra-b>
-          <inst-ra-gain type="double">1.15</inst-ra-gain>
+          <ra-r type="double">0.055</ra-r>
+          <ra-g type="double">0.030</ra-g>
+          <ra-b type="double">0.030</ra-b>
+          <inst-ra-gain type="double">1.11</inst-ra-gain>
           <glare-ra-gain type="double">0.5</glare-ra-gain>
       </lighting>
       

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -415,9 +415,11 @@
                 <immat-on-panel>true</immat-on-panel>
 
       <lighting>
-          <ra-r type="double">0.05</ra-r>
-          <ra-g type="double">0.025</ra-g>
-          <ra-b type="double">0.025</ra-b>
+          <ra-r type="double">0.095</ra-r>
+          <ra-g type="double">0.065</ra-g>
+          <ra-b type="double">0.065</ra-b>
+          <inst-ra-gain type="double">1.15</inst-ra-gain>
+          <glare-ra-gain type="double">0.5</glare-ra-gain>
       </lighting>
       
       <parachuters>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -415,10 +415,10 @@
                 <immat-on-panel>true</immat-on-panel>
 
       <lighting>
-          <ra-r type="double">0.095</ra-r>
-          <ra-g type="double">0.065</ra-g>
-          <ra-b type="double">0.065</ra-b>
-          <inst-ra-gain type="double">1.15</inst-ra-gain>
+          <ra-r type="double">0.055</ra-r>
+          <ra-g type="double">0.030</ra-g>
+          <ra-b type="double">0.030</ra-b>
+          <inst-ra-gain type="double">1.11</inst-ra-gain>
           <glare-ra-gain type="double">0.5</glare-ra-gain>
       </lighting>
       


### PR DESCRIPTION
At nighttime, the radio stack and instrument lighting should briefly illuminate the cabin.
The current effect was so faint, that it was not visible in most cases.
Therefore this commit makes the effect a little more prominent.

Also, the radio stack lighting was not correct:
- the COM radios were not adressed correctly and thus never added light to the mix
- Some equipment is not lit when the radio stack light knob is off
- COM units should have a bigger effect on brightness than other equipment (it has more red lights)