### PR TITLE
Issue525 save dg offset (by switching instrument to <heading-indicator-dg>)

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -61,6 +61,11 @@ When parking the plane after flight, you should go to 1800 RPM and lean mix for 
 - `Winter Kit`  
   The winter kit is needed in cold weather (<20°F/-6°C) to reduce cooling air flow. If not supplied, the engine will possibly not get warm enough to develop good power, but be sure to remove it in hot weather, otherwise you risk too high CHT temps.
 
+### Realistic Instruments
+When this option is activated, some instruments will be simulated more realistically.  
+The gyro based instruments will need more time to spin up fully (2-3 minutes), so for example give the HI/DG time before trying to calibrate it. Also, excess forces (steep turns, high G-loads) can introduce errors or even induce tumbling of the gyro.  
+The HI will be affected by some expected errors like precession due to earths rotation, as well as transport wander, so you need to check and recalibrate the instrument every 15 minutes or so.
+
 ### Autostart
 The c182 features an autostart- and autoshutdown option which can be used to quickly start/stop the engine. The corresponding checklist items
 will be run trough, so for example autostart will take care of removing tiedowns and check fuel contamination for you, as well as ensuring good battery, enough oil and fuel. Shutdown will secure the airplane on the ground.

--- a/Models/Instruments/Compass.xml
+++ b/Models/Instruments/Compass.xml
@@ -122,7 +122,7 @@
       <command>set-tooltip</command>
       <tooltip-id>heading-bug</tooltip-id>
       <mapping>heading</mapping>
-      <label>Compass: %3.f</label>
+      <label>Compass: %3.0f</label>
       <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
     </binding>
   </hovered>

--- a/Models/Instruments/ai-gauge.xml
+++ b/Models/Instruments/ai-gauge.xml
@@ -206,10 +206,16 @@
   <object-name>InopIndicator</object-name>
   <condition>
     <not>
+      <and>
         <greater-than>
             <property>instrumentation/attitude-indicator/spin</property>
-            <value>0.50</value>
+            <value>0.80</value> <!-- to match <spin_thresh> config prop instrumentation.xml -->
         </greater-than>
+        <greater-than>
+            <property>/systems/vacuum/suction-inhg</property>
+            <value>3.80</value>
+        </greater-than>
+      </and>
     </not>
   </condition>
  </animation>

--- a/Models/Instruments/hi.xml
+++ b/Models/Instruments/hi.xml
@@ -143,6 +143,17 @@
 			<z>0</z>
 		</axis>
   </animation>
+  <animation>
+    <type>translate</type>
+    <object-name>OBS-Knob</object-name>
+    <property>instrumentation/heading-indicator/caged-flag</property>
+    <factor>0.004</factor>
+    <axis>
+        <x>-1.0</x>
+        <y>0.0</y>
+        <z>0.0</z>
+    </axis>
+  </animation>
 
 <!--     Heading Bug control    -->
  <animation>
@@ -190,21 +201,114 @@
       </binding>
       <binding>
         <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
+      </binding>
+      <binding>
+        <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
     </action>
+    <shift-action>
+      <binding>
+        <condition>
+          <greater-than>
+            <property>/sim/time/elapsed-sec</property>
+            <expression>
+              <sum>
+                <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+                <value>1</value>
+              </sum>
+            </expression>
+          </greater-than>
+        </condition>
+        <command>property-toggle</command>
+        <property>instrumentation/heading-indicator/caged-flag</property>
+      </binding>
+
+      <binding>
+        <condition>
+          <less-than-equals>
+            <property>/sim/time/elapsed-sec</property>
+            <expression>
+              <sum>
+                <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+                <value>1</value>
+              </sum>
+            </expression>
+          </less-than-equals>
+        </condition>
+        <command>property-adjust</command>
+        <property>instrumentation/heading-indicator/align-deg</property>
+        <factor>5</factor>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
+        <condition>
+          <less-than-equals>
+            <property>/sim/time/elapsed-sec</property>
+            <expression>
+              <sum>
+                <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+                <value>1</value>
+              </sum>
+            </expression>
+          </less-than-equals>
+        </condition>
+        <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving, uncage afterwards
+            setprop("instrumentation/heading-indicator/caged-flag", 1);
+            
+            var rotateAction = maketimer(1.0, func {
+                setprop("instrumentation/heading-indicator/caged-flag", 0);
+            });
+            rotateAction.singleShot = 1;
+            rotateAction.start();
+        ]]></script>
+      </binding>
+      <binding>
+        <command>property-assign</command>
+        <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+        <property>/sim/time/elapsed-sec</property>
+      </binding>
+      <binding>
+        <command>nasal</command>
+        <script>c182s.click("heading-offset-dial")</script>
+      </binding>
+    </shift-action>
   
     <!-- faster rate of change than the default -->
     <drag-scale-px>4</drag-scale-px>
-    <shift-repeat type="int">5</shift-repeat>
     
     <hovered>
       <binding>
         <command>set-tooltip</command>
         <tooltip-id>heading-offset</tooltip-id>
-        <label>Heading: %3.0f</label>
-        <property>instrumentation/heading-indicator/indicated-heading-deg</property>
-        <mapping>heading</mapping>
+        <label>%s</label>
+        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+        <mapping>nasal</mapping>
+        <script>
+          var heading = getprop("instrumentation/heading-indicator/indicated-heading-deg");
+          var returnString = "Heading: " ~ sprintf("%3.0f", heading);
+          if (getprop("instrumentation/heading-indicator/caged-flag")) {
+              returnString = returnString ~ "\n(caged)";
+          }
+          return returnString;
+        </script>
       </binding>
     </hovered>
    </animation>
@@ -453,6 +557,22 @@
         <max>360</max>
         <wrap>1</wrap>
       </binding>
+      <binding>
+        <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
+      </binding>
     </action>  
     <action>
       <name>large decrease</name>
@@ -465,6 +585,22 @@
         <min>0</min>
         <max>360</max>
         <wrap>1</wrap>
+      </binding>
+      <binding>
+        <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
       </binding>
       <binding>
         <command>nasal</command>
@@ -507,6 +643,22 @@
       </binding>
       <binding>
         <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
+      </binding>
+      <binding>
+        <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
     </action>  
@@ -546,6 +698,22 @@
       </binding>
       <binding>
         <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
+      </binding>
+      <binding>
+        <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
     </action>
@@ -553,9 +721,17 @@
       <binding>
         <command>set-tooltip</command>
         <tooltip-id>heading-offset</tooltip-id>
-        <label>Heading: %3.0f</label>
-        <property>instrumentation/heading-indicator/indicated-heading-deg</property>
-        <mapping>heading</mapping>
+        <label>%s</label>
+        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+        <mapping>nasal</mapping>
+        <script>
+          var heading = getprop("instrumentation/heading-indicator/indicated-heading-deg");
+          var returnString = "Heading: " ~ sprintf("%3.0f", heading);
+          if (getprop("instrumentation/heading-indicator/caged-flag")) {
+              returnString = returnString ~ "\n(caged)";
+          }
+          return returnString;
+        </script>
       </binding>
     </hovered>
   </animation>
@@ -602,6 +778,22 @@
         <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
+      <binding>
+        <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
+      </binding>
     </action>  
     <action>
       <name>large increase</name>
@@ -618,6 +810,22 @@
       <binding>
         <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
+      </binding>
+      <binding>
+        <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
       </binding>
     </action>
     <action>
@@ -653,6 +861,22 @@
         <min>0</min>
         <max>360</max>
         <wrap>1</wrap>
+      </binding>
+      <binding>
+        <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
       </binding>
       <binding>
         <command>nasal</command>
@@ -695,6 +919,22 @@
       </binding>
       <binding>
         <command>nasal</command>
+        <script><![CDATA[
+            # Cage gyro when moving
+            var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+            if (!oldSetting) {
+              setprop("instrumentation/heading-indicator/caged-flag", 1);
+              
+              var rotateAction = maketimer(1.0, func {
+                  setprop("instrumentation/heading-indicator/caged-flag", 0);
+              });
+              rotateAction.singleShot = 1;
+              rotateAction.start();
+            }
+        ]]></script>
+      </binding>
+      <binding>
+        <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
     </action>
@@ -702,9 +942,17 @@
       <binding>
         <command>set-tooltip</command>
         <tooltip-id>heading-offset</tooltip-id>
-        <label>Heading: %3.0f</label>
-        <property>instrumentation/heading-indicator/indicated-heading-deg</property>
-        <mapping>heading</mapping>
+        <label>%s</label>
+        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+        <mapping>nasal</mapping>
+        <script>
+          var heading = getprop("instrumentation/heading-indicator/indicated-heading-deg");
+          var returnString = "Heading: " ~ sprintf("%3.0f", heading);
+          if (getprop("instrumentation/heading-indicator/caged-flag")) {
+              returnString = returnString ~ "\n(caged)";
+          }
+          return returnString;
+        </script>
       </binding>
     </hovered>
   </animation>

--- a/Models/Instruments/hi.xml
+++ b/Models/Instruments/hi.xml
@@ -113,35 +113,35 @@
   <animation>
     <type>rotate</type>
     <object-name>Hdg-Knob</object-name>
-     <property>autopilot/settings/heading-bug-deg</property>
-<factor>10</factor>
-		<center>
-			<x-m>0.012891</x-m>
-			<y-m>0.035372</y-m>
-			<z-m>-0.033017</z-m>
-		</center>
-		<axis>
-			<x>-0.013332</x>
-			<y>0</y>
-			<z>0</z>
-		</axis>
+    <property>autopilot/settings/heading-bug-deg</property>
+    <factor>10</factor>
+    <center>
+      <x-m>0.012891</x-m>
+      <y-m>0.035372</y-m>
+      <z-m>-0.033017</z-m>
+    </center>
+    <axis>
+      <x>-0.013332</x>
+      <y>0</y>
+      <z>0</z>
+    </axis>
   </animation>
   
   <animation>
     <type>rotate</type>
     <object-name>OBS-Knob</object-name>
-     <property>instrumentation/heading-indicator/align-deg</property>
-<factor>10</factor>
-		<center>
-			<x-m>0.012842</x-m>
-			<y-m>-0.034351</y-m>
-			<z-m>-0.033017</z-m>
-		</center>
-		<axis>
-			<x>-0.01343</x>
-			<y>0</y>
-			<z>0</z>
-		</axis>
+    <property>instrumentation/heading-indicator/align-deg</property>
+    <factor>10</factor>
+    <center>
+      <x-m>0.012842</x-m>
+      <y-m>-0.034351</y-m>
+      <z-m>-0.033017</z-m>
+    </center>
+    <axis>
+      <x>-0.01343</x>
+      <y>0</y>
+      <z>0</z>
+    </axis>
   </animation>
   <animation>
     <type>translate</type>

--- a/Models/Instruments/hi.xml
+++ b/Models/Instruments/hi.xml
@@ -182,14 +182,6 @@
     <action>
       <binding>
         <command>property-adjust</command>
-        <property>instrumentation/heading-indicator/offset-deg</property>
-        <factor>1</factor>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>instrumentation/heading-indicator/align-deg</property>
         <factor>1</factor>
         <min>0</min>
@@ -429,14 +421,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>1</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>1</step>
         <min>0</min>
@@ -452,7 +436,7 @@
           <property>/devices/status/keyboard/shift</property>
         </condition>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>4</step>
         <min>0</min>
         <max>360</max>
@@ -476,14 +460,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>5</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>5</step>
         <min>0</min>
@@ -501,14 +477,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>-1</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-1</step>
         <min>0</min>
@@ -520,7 +488,7 @@
           <property>/devices/status/keyboard/shift</property>
         </condition>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-4</step>
         <min>0</min>
         <max>360</max>
@@ -548,14 +516,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>1</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>1</step>
         <min>0</min>
@@ -567,7 +527,7 @@
           <property>/devices/status/keyboard/shift</property>
         </condition>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>4</step>
         <min>0</min>
         <max>360</max>
@@ -610,14 +570,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>-1</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-1</step>
         <min>0</min>
@@ -629,7 +581,7 @@
           <property>/devices/status/keyboard/shift</property>
         </condition>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-4</step>
         <min>0</min>
         <max>360</max>
@@ -657,14 +609,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>-5</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-5</step>
         <min>0</min>
@@ -682,14 +626,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>-1</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-1</step>
         <min>0</min>
@@ -701,7 +637,7 @@
           <property>/devices/status/keyboard/shift</property>
         </condition>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-4</step>
         <min>0</min>
         <max>360</max>
@@ -729,14 +665,6 @@
       <repeatable>true</repeatable>
       <binding>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
-        <step>1</step>
-        <min>0</min>
-        <max>360</max>
-        <wrap>1</wrap>
-      </binding>
-      <binding>
-        <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/align-deg</property>
         <step>1</step>
         <min>0</min>
@@ -748,7 +676,7 @@
           <property>/devices/status/keyboard/shift</property>
         </condition>
         <command>property-adjust</command>
-        <property>/instrumentation/heading-indicator/offset-deg</property>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>4</step>
         <min>0</min>
         <max>360</max>

--- a/Nasal/c182s-states.nas
+++ b/Nasal/c182s-states.nas
@@ -69,6 +69,11 @@ var cleanAircraft = func() {
 }
 
 var calibrateInstruments = func() {
+    # Insta-Spin up gyros
+    setprop("/instrumentation/heading-indicator/spin", 1.0);
+    setprop("/instrumentation/turn-indicator/spin", 1.0);
+    setprop("/instrumentation/attitude-indicator/spin", 1.0);
+    
     # Set the altimeter
     var pressure_sea_level = getprop("/environment/pressure-sea-level-inhg");
     pressure_sea_level     = sprintf("%.2f", pressure_sea_level);
@@ -77,7 +82,6 @@ var calibrateInstruments = func() {
 
     # Set heading indicator alignment
     # Note: this needs a correctly spun up gyro to work.
-    setprop("/instrumentation/heading-indicator/spin", 1.0);
     var magnetic_variation = getprop("/environment/magnetic-variation-deg");
     magnetic_variation     = sprintf("%.2f", magnetic_variation);
     setprop("/instrumentation/heading-indicator/align-deg", -magnetic_variation);

--- a/Nasal/c182s-states.nas
+++ b/Nasal/c182s-states.nas
@@ -85,7 +85,8 @@ var calibrateInstruments = func() {
     var magnetic_variation = getprop("/environment/magnetic-variation-deg");
     magnetic_variation     = sprintf("%.2f", magnetic_variation);
     setprop("/instrumentation/heading-indicator/align-deg", -magnetic_variation);
-    setprop("/instrumentation/heading-indicator/offset-deg", -magnetic_variation);
+    setprop("/instrumentation/heading-indicator/error-deg", 0);
+    setprop("/instrumentation/heading-indicator/offset-deg", 0);
     print("Heading Indicator calibrated to: " ~ magnetic_variation ~ " magVar");
 }
 

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -1001,6 +1001,24 @@ setlistener("/sim/signals/fdm-initialized", func {
         };
         print("C182 FGCamera integration loaded");
     }
+    
+    # DG: Reset offset to stored value
+    # for some unknown (to me) reason, the DG offset is set to something obscure after initialization; and the value is location specific...
+    # So we store the last known value when the im exits and restore that here
+    var dg_offset_startup = getprop("/instrumentation/heading-indicator/offset-deg-save") or 0;
+    var dg_offset_storemode = 0;
+    var dg_offset_startup_timer = maketimer(1.0, func(){
+        dg_offset_now = getprop("/instrumentation/heading-indicator/offset-deg") or 0;
+        if (dg_offset_storemode == 0) {
+            print("c182 restore DG offset from "~dg_offset_now~" to "~dg_offset_startup~" (saved value)");
+            setprop("/instrumentation/heading-indicator/offset-deg", dg_offset_startup);
+            dg_offset_storemode = 1;
+        } else {
+            #print("c182 updating stored DG offset to "~dg_offset_now);
+            setprop("/instrumentation/heading-indicator/offset-deg-save", dg_offset_now);
+        }
+    });
+    dg_offset_startup_timer.start();
 
 
     # If we are starting outside and in cold weather, add some ice/snow to the plane
@@ -1037,6 +1055,7 @@ setlistener("/sim/signals/fdm-initialized", func {
 
 
 });
+
 
 
 # generate legacy author property (used by the about dialog)

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -59,7 +59,9 @@ file, these values will be used (they are hardcoded).
     <suction>/systems/vacuum/suction-inhg</suction>
     <minimum-vacuum>4.5</minimum-vacuum>  <!-- source: https://www.kellymfg.com/images/RC%20ALLEN%20Catalog.pdf -->
     <limits>
-      <spin_thresh>0.8</spin_thresh>
+      <spin-thresh>0.8</spin-thresh>
+      <max-roll-error-deg>40.0</max-roll-error-deg>
+      <max-pitch-error-deg>12.0</max-pitch-error-deg>
     </limits>
     <gyro>
       <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
@@ -98,15 +100,15 @@ file, these values will be used (they are hardcoded).
     <suction>/systems/vacuum/suction-inhg</suction>
     <minimum-vacuum>4.0</minimum-vacuum>  <!-- source: https://www.kellymfg.com/images/RC%20ALLEN%20Catalog.pdf -->
     <limits>
-      <minimum-spin-norm>0.8</minimum-spin-norm>
-      <yaw-limit-rate>7.0</yaw-limit-rate> <!-- about 40° bank -->
-      <g-limit-lower>-0.8</g-limit-lower>
-      <g-limit-upper>1.8</g-limit-upper>
-      <!--<yaw-error-factor>0.033</yaw-error-factor>-->
-      <!--<g-error-factor>0.033</g-error-factor>-->
-      <!--<g-limit-tumble-factor>1.5</g-limit-tumble-factor>-->
+      <yaw-limit-rate>11.5</yaw-limit-rate> <!-- about 55° bank, from video footage, see refs in https://github.com/HHS81/c182s/pull/527 -->
+      <yaw-error-factor>0.033</yaw-error-factor>
+      <g-limit-lower>-0.85</g-limit-lower>
+      <g-limit-upper>2.0</g-limit-upper>
+      <g-error-factor>0.033</g-error-factor>
+      <g-limit-tumble-factor>1.5</g-limit-tumble-factor>
     </limits>
     <gyro>
+      <minimum-spin-norm>0.8</minimum-spin-norm>
       <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
       <spin-down-sec>300.0</spin-down-sec> <!-- ~5 minutes -->
     </gyro>

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -88,6 +88,13 @@ file, these values will be used (they are hardcoded).
     <name>heading-indicator</name>
     <number>0</number>
     <suction>/systems/vacuum/suction-inhg</suction>
+    <minimum-vacuum>4.5</minimum-vacuum>
+    <minimum-spin-norm>0.8</minimum-spin-norm>
+    <yaw-limit-rate>7.0</yaw-limit-rate> <!-- about 40° bank -->
+    <g-limit-lower>-0.8</g-limit-lower>
+    <g-limit-upper>1.8</g-limit-upper>
+    <!--<yaw-error-factor>0.033</yaw-error-factor>-->
+    <!--<g-error-factor>0.033</g-error-factor>-->
   </heading-indicator-dg>
 
   <magnetic-compass>

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -58,9 +58,13 @@ file, these values will be used (they are hardcoded).
     <number>0</number>
     <suction>/systems/vacuum/suction-inhg</suction>
     <minimum-vacuum>4.5</minimum-vacuum>  <!-- source: https://www.kellymfg.com/images/RC%20ALLEN%20Catalog.pdf -->
-    <spin_thresh>0.8</spin_thresh>
-    <gyro-spin-up-sec>180.0</gyro-spin-up-sec>     <!-- ~3 minutes -->
-    <gyro-spin-down-sec>300.0</gyro-spin-down-sec> <!-- ~5 minutes -->
+    <limits>
+      <spin_thresh>0.8</spin_thresh>
+    </limits>
+    <gyro>
+      <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
+      <spin-down-sec>300.0</spin-down-sec> <!-- ~5 minutes -->
+    </gyro>
   </attitude-indicator>
 
   <clock>
@@ -93,15 +97,19 @@ file, these values will be used (they are hardcoded).
     <number>0</number>
     <suction>/systems/vacuum/suction-inhg</suction>
     <minimum-vacuum>4.0</minimum-vacuum>  <!-- source: https://www.kellymfg.com/images/RC%20ALLEN%20Catalog.pdf -->
-    <minimum-spin-norm>0.8</minimum-spin-norm>
-    <yaw-limit-rate>7.0</yaw-limit-rate> <!-- about 40° bank -->
-    <g-limit-lower>-0.8</g-limit-lower>
-    <g-limit-upper>1.8</g-limit-upper>
-    <!--<yaw-error-factor>0.033</yaw-error-factor>-->
-    <!--<g-error-factor>0.033</g-error-factor>-->
-    <!--<g-limit-tumble-factor>1.5</g-limit-tumble-factor>-->
-    <gyro-spin-up-sec>180.0</gyro-spin-up-sec>     <!-- ~3 minutes -->
-    <gyro-spin-down-sec>300.0</gyro-spin-down-sec> <!-- ~5 minutes -->
+    <limits>
+      <minimum-spin-norm>0.8</minimum-spin-norm>
+      <yaw-limit-rate>7.0</yaw-limit-rate> <!-- about 40° bank -->
+      <g-limit-lower>-0.8</g-limit-lower>
+      <g-limit-upper>1.8</g-limit-upper>
+      <!--<yaw-error-factor>0.033</yaw-error-factor>-->
+      <!--<g-error-factor>0.033</g-error-factor>-->
+      <!--<g-limit-tumble-factor>1.5</g-limit-tumble-factor>-->
+    </limits>
+    <gyro>
+      <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
+      <spin-down-sec>300.0</spin-down-sec> <!-- ~5 minutes -->
+    </gyro>
   </heading-indicator-dg>
 
   <magnetic-compass>
@@ -159,8 +167,10 @@ file, these values will be used (they are hardcoded).
     <name>turn-indicator</name>
     <number>0</number>
     <power-supply>systems/electrical/outputs/turn-coordinator</power-supply>
-    <gyro-spin-up-sec>180.0</gyro-spin-up-sec>     <!-- ~3 minutes -->
-    <gyro-spin-down-sec>300.0</gyro-spin-down-sec> <!-- ~5 minutes -->
+    <gyro>
+      <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
+      <spin-down-sec>300.0</spin-down-sec> <!-- ~5 minutes -->
+    </gyro>
   </turn-indicator>
 
   <vertical-speed-indicator>

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -96,6 +96,8 @@ file, these values will be used (they are hardcoded).
     <!--<yaw-error-factor>0.033</yaw-error-factor>-->
     <!--<g-error-factor>0.033</g-error-factor>-->
     <!--<g-limit-tumble-factor>1.5</g-limit-tumble-factor>-->
+    <gyro-spin-up-sec>180.0</gyro-spin-up-sec>     <!-- ~3 minutes -->
+    <gyro-spin-down-sec>300.0</gyro-spin-down-sec> <!-- ~5 minutes -->
   </heading-indicator-dg>
 
   <magnetic-compass>

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -95,6 +95,7 @@ file, these values will be used (they are hardcoded).
     <g-limit-upper>1.8</g-limit-upper>
     <!--<yaw-error-factor>0.033</yaw-error-factor>-->
     <!--<g-error-factor>0.033</g-error-factor>-->
+    <!--<g-limit-tumble-factor>1.5</g-limit-tumble-factor>-->
   </heading-indicator-dg>
 
   <magnetic-compass>

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -4,7 +4,7 @@
 **********************************************************************
 instrumentation.xml
 
-c172p instrumentation configuration. This file selects the
+c182s instrumentation configuration. This file selects the
 instrumentation modules that should be available.
 
 You can have several instances of the same instrument type.
@@ -57,6 +57,10 @@ file, these values will be used (they are hardcoded).
     <name>attitude-indicator</name>
     <number>0</number>
     <suction>/systems/vacuum/suction-inhg</suction>
+    <minimum-vacuum>4.5</minimum-vacuum>  <!-- source: https://www.kellymfg.com/images/RC%20ALLEN%20Catalog.pdf -->
+    <spin_thresh>0.8</spin_thresh>
+    <gyro-spin-up-sec>180.0</gyro-spin-up-sec>     <!-- ~3 minutes -->
+    <gyro-spin-down-sec>300.0</gyro-spin-down-sec> <!-- ~5 minutes -->
   </attitude-indicator>
 
   <clock>
@@ -88,7 +92,7 @@ file, these values will be used (they are hardcoded).
     <name>heading-indicator</name>
     <number>0</number>
     <suction>/systems/vacuum/suction-inhg</suction>
-    <minimum-vacuum>4.5</minimum-vacuum>
+    <minimum-vacuum>4.0</minimum-vacuum>  <!-- source: https://www.kellymfg.com/images/RC%20ALLEN%20Catalog.pdf -->
     <minimum-spin-norm>0.8</minimum-spin-norm>
     <yaw-limit-rate>7.0</yaw-limit-rate> <!-- about 40° bank -->
     <g-limit-lower>-0.8</g-limit-lower>
@@ -155,6 +159,8 @@ file, these values will be used (they are hardcoded).
     <name>turn-indicator</name>
     <number>0</number>
     <power-supply>systems/electrical/outputs/turn-coordinator</power-supply>
+    <gyro-spin-up-sec>180.0</gyro-spin-up-sec>     <!-- ~3 minutes -->
+    <gyro-spin-down-sec>300.0</gyro-spin-down-sec> <!-- ~5 minutes -->
   </turn-indicator>
 
   <vertical-speed-indicator>

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -84,11 +84,11 @@ file, these values will be used (they are hardcoded).
     <number>0</number>
   </marker-beacon>
 
-  <heading-indicator>
+  <heading-indicator-dg>
     <name>heading-indicator</name>
     <number>0</number>
     <suction>/systems/vacuum/suction-inhg</suction>
-  </heading-indicator>
+  </heading-indicator-dg>
 
   <magnetic-compass>
     <name>magnetic-compass</name>

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -887,4 +887,21 @@
     </filter>
     
     
+    <!-- Enforce unrealistic instrument behaviour for gyro instruments -->
+    <logic>
+      <name>Unrealistic gyro instruments settings</name>
+      <input>
+        <condition>
+          <property>/sim/realism/instruments/realistic-gyros</property>
+        </condition>
+        <value>1</value>
+      </input>
+      <input>
+        <value>0</value>
+      </input>
+      <output>
+          <property>/instrumentation/heading-indicator/latitude-nut-setting-autoset</property>
+      </output>
+    </logic>
+
 </PropertyList>

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -805,7 +805,7 @@
             <property>instrumentation/magnetic-compass/roll-deg-final</property>
         </output>
     </filter>
-    
+
     <!-- VSI damper -->
     <!-- To dampen the needle a bit more, especially at very tiny changes (like parking) -->
     <!-- By observation, it fluctuates around -20/+20 in a seemingly random manner. -->

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -885,23 +885,5 @@
           <property>instrumentation/vertical-speed-indicator/indicated-speed-fpm-final</property>
       </output>
     </filter>
-    
-    
-    <!-- Enforce unrealistic instrument behaviour for gyro instruments -->
-    <logic>
-      <name>Unrealistic gyro instruments settings</name>
-      <input>
-        <condition>
-          <property>/sim/realism/instruments/realistic-gyros</property>
-        </condition>
-        <value>1</value>
-      </input>
-      <input>
-        <value>0</value>
-      </input>
-      <output>
-          <property>/instrumentation/heading-indicator/latitude-nut-setting-autoset</property>
-      </output>
-    </logic>
 
 </PropertyList>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -1080,8 +1080,9 @@
             <path>/instrumentation/attitude-indicator/caged-flag</path>
             <path>/instrumentation/attitude-indicator/horizon-offset-deg</path>
             <path>/instrumentation/airspeed-indicator/tas-face-rotation</path>
-            <path>/instrumentation/heading-indicator/offset-deg</path>
             <path>/instrumentation/heading-indicator/align-deg</path>
+            <path>/instrumentation/heading-indicator/error-deg</path>
+            <path>/instrumentation/heading-indicator/offset-deg-save</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -62,7 +62,7 @@
             <tag>high-wing</tag>
             <tag>dual-controls</tag>
         </tags>
-    <minimum-fg-version>2018.3.0</minimum-fg-version>
+    <minimum-fg-version>2020.4.0</minimum-fg-version>
     <rating>
       <FDM type="int">5</FDM>
       <systems type="int">5</systems>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -248,7 +248,7 @@
   
   <realism>
     <instruments>
-      <realistic-instruments type="bool">true</realistic-instruments>
+      <realistic-instruments type="bool">false</realistic-instruments>
     </instruments>
   </realism>
 

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -245,6 +245,12 @@
       <available>true</available>
     </pilot-model>
   </rendering>
+  
+  <realism>
+    <instruments>
+      <realistic-instruments type="bool">true</realistic-instruments>
+    </instruments>
+  </realism>
 
 <instrumentation n="0">
     <path>Aircraft/c182s/Systems/instrumentation.xml</path>
@@ -1086,7 +1092,7 @@
             <path>/instrumentation/heading-indicator/offset-deg-saved</path>
             <path>/instrumentation/heading-indicator/caged-flag</path>
             <path>/instrumentation/heading-indicator/latitude-nut-setting</path>
-            <path>/instrumentation/heading-indicator/latitude-nut-setting-autoset</path>
+            <path>/sim/realism/instruments/realistic-instruments</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -1083,6 +1083,7 @@
             <path>/instrumentation/heading-indicator/align-deg</path>
             <path>/instrumentation/heading-indicator/error-deg</path>
             <path>/instrumentation/heading-indicator/offset-deg-save</path>
+            <path>/instrumentation/heading-indicator/caged-flag</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -1084,6 +1084,8 @@
             <path>/instrumentation/heading-indicator/error-deg</path>
             <path>/instrumentation/heading-indicator/offset-deg-save</path>
             <path>/instrumentation/heading-indicator/caged-flag</path>
+            <path>/instrumentation/heading-indicator/latitude-nut-setting</path>
+            <path>/instrumentation/heading-indicator/latitude-nut-setting-autoset</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -1081,8 +1081,9 @@
             <path>/instrumentation/attitude-indicator/horizon-offset-deg</path>
             <path>/instrumentation/airspeed-indicator/tas-face-rotation</path>
             <path>/instrumentation/heading-indicator/align-deg</path>
-            <path>/instrumentation/heading-indicator/error-deg</path>
-            <path>/instrumentation/heading-indicator/offset-deg-save</path>
+            <path>/orientation/heading-deg-saved</path>
+            <path>/instrumentation/heading-indicator/error-deg-saved</path>
+            <path>/instrumentation/heading-indicator/offset-deg-saved</path>
             <path>/instrumentation/heading-indicator/caged-flag</path>
             <path>/instrumentation/heading-indicator/latitude-nut-setting</path>
             <path>/instrumentation/heading-indicator/latitude-nut-setting-autoset</path>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -229,6 +229,12 @@
     </pilot-model>
   </rendering>
 
+  <realism>
+    <instruments>
+      <realistic-instruments type="bool">true</realistic-instruments>
+    </instruments>
+  </realism>
+
 <instrumentation n="0">
     <path>Aircraft/c182s/Systems/instrumentation.xml</path>
   </instrumentation>
@@ -981,7 +987,7 @@
             <path>/instrumentation/heading-indicator/offset-deg-save</path>
             <path>/instrumentation/heading-indicator/caged-flag</path>
             <path>/instrumentation/heading-indicator/latitude-nut-setting</path>
-            <path>/instrumentation/heading-indicator/latitude-nut-setting-autoset</path>
+            <path>/sim/realism/instruments/realistic-instruments</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -61,7 +61,7 @@
             <tag>ifr</tag>
             <tag>high-wing</tag>
         </tags>
-    <minimum-fg-version>2017.3.1</minimum-fg-version>
+    <minimum-fg-version>2020.4.0</minimum-fg-version>
     <rating>
       <FDM type="int">5</FDM>
       <systems type="int">3</systems>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -231,7 +231,7 @@
 
   <realism>
     <instruments>
-      <realistic-instruments type="bool">true</realistic-instruments>
+      <realistic-instruments type="bool">false</realistic-instruments>
     </instruments>
   </realism>
 

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -980,6 +980,8 @@
             <path>/instrumentation/heading-indicator/error-deg</path>
             <path>/instrumentation/heading-indicator/offset-deg-save</path>
             <path>/instrumentation/heading-indicator/caged-flag</path>
+            <path>/instrumentation/heading-indicator/latitude-nut-setting</path>
+            <path>/instrumentation/heading-indicator/latitude-nut-setting-autoset</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -976,8 +976,9 @@
             <path>/instrumentation/attitude-indicator/caged-flag</path>
             <path>/instrumentation/attitude-indicator/horizon-offset-deg</path>
             <path>/instrumentation/airspeed-indicator/tas-face-rotation</path>
-            <path>/instrumentation/heading-indicator/offset-deg</path>
             <path>/instrumentation/heading-indicator/align-deg</path>
+            <path>/instrumentation/heading-indicator/error-deg</path>
+            <path>/instrumentation/heading-indicator/offset-deg-save</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -979,6 +979,7 @@
             <path>/instrumentation/heading-indicator/align-deg</path>
             <path>/instrumentation/heading-indicator/error-deg</path>
             <path>/instrumentation/heading-indicator/offset-deg-save</path>
+            <path>/instrumentation/heading-indicator/caged-flag</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -106,23 +106,6 @@
             </binding>
         </button>
     </group>
-    <group>
-        <layout>vbox</layout>
-        <padding>8</padding>
-        <checkbox>
-            <halign>left</halign>
-            <label>Autoset periodically and on sim startup</label>
-            <property>/instrumentation/heading-indicator/latitude-nut-setting-autoset</property>
-            <live>true</live>
-            <binding>
-                <command>property-toggle</command>
-                <property>/instrumentation/heading-indicator/latitude-nut-setting-autoset</property>
-            </binding>
-            <binding>
-                <command>dialog-update</command><!-- makes sure that command is still there when dialog is closed-->
-            </binding>
-        </checkbox>
-    </group>
     
     <hrule/>
     
@@ -286,9 +269,24 @@
                 
                 <empty><stretch>true</stretch></empty> <!-- force group to the left -->
             </group>
-            
-            
+
         </group>
+        
+        <checkbox>
+            <halign>left</halign>
+            <label>Realistic Instruments</label>
+            <property>/sim/realism/instruments/realistic-instruments</property>
+            <live>true</live>
+            <binding>
+                <command>property-toggle</command>
+                <property>/sim/realism/instruments/realistic-instruments</property>
+            </binding>
+            <binding>
+                <command>dialog-update</command><!-- makes sure that command is still there when dialog is closed-->
+            </binding>
+        </checkbox>
+        
+        <hrule/>
         
         <checkbox>
             <halign>left</halign>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -20,6 +20,15 @@
     <modal>false</modal>
     <draggable>true</draggable>
 
+    <nasal>
+        <open><![CDATA[
+            # Ensure latitude nut has a value
+            var latnutprop = "/instrumentation/heading-indicator/latitude-nut-setting";
+            if (!getprop(latnutprop))
+                setprop(latnutprop, 0);
+        ]]></open>
+    </nasal>
+
 
     <group>
         <layout>hbox</layout>
@@ -67,6 +76,52 @@
                 <command>dialog-close</command>
             </binding>
         </button>
+    </group>
+    
+    <group>
+        <layout>hbox</layout>
+
+        <text>
+            <label>HI/DG Latitude Nut setting:</label>
+            <halign>left</halign>
+        </text>
+    
+        <input>
+            <name>latitude-nut-setting</name>
+            <halign>left</halign>
+            <property>/instrumentation/heading-indicator/latitude-nut-setting</property>
+            <type>INT</type>
+            <width>2</width>
+        </input>
+        <button>
+            <legend>Apply</legend>
+            <equal>true</equal>
+            <default>false</default>
+            <binding>
+                <command>dialog-apply</command>
+                <object-name>latitude-nut-setting</object-name>
+            </binding>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+    <group>
+        <layout>vbox</layout>
+        <padding>8</padding>
+        <checkbox>
+            <halign>left</halign>
+            <label>Autoset periodically and on sim startup</label>
+            <property>/instrumentation/heading-indicator/latitude-nut-setting-autoset</property>
+            <live>true</live>
+            <binding>
+                <command>property-toggle</command>
+                <property>/instrumentation/heading-indicator/latitude-nut-setting-autoset</property>
+            </binding>
+            <binding>
+                <command>dialog-update</command><!-- makes sure that command is still there when dialog is closed-->
+            </binding>
+        </checkbox>
     </group>
     
     <hrule/>


### PR DESCRIPTION
This switches the heading indicator to the `heading-indicator-dg` implementation which is more powerful and realistic.

:warning: PR is based on switching to the DG based heading indicator, and only works with the patch to the core:
https://sourceforge.net/p/flightgear/codetickets/2839/

:information_source: Regarding the movement-errors, there is discussion on the mailing list if this is realistic:  https://sourceforge.net/p/flightgear/mailman/flightgear-devel/thread/6e66f08e3fb3f02a9d5c557cfd7a2910%40hallinger.org/#msg53245268
My impression is, that there should be no permanent movement related errors, as the gyro should move relatively freely due to the two axis bearing.

regarding to the videos:
- Uncaged maneuver limits are (for air driven): +-55° in pitch or roll (two videos below say this). IMHO the current c++ coded limits are too rigid. And also it would be nice to have a caging feature.
- Mechanical limits prevent completely freely movement.

----
- [x] Switch to new DG
- [x] error value: only let this apply when the limits (55° pitch/bank) are exceeded
- :warning: _Before merge_;
  - [x] Wait for SF ticket [2839](https://sourceforge.net/p/flightgear/codetickets/2839/) being merged to FGFS/next (so `<suction>` is a supported source of the instrument)
  - [x] Watch SF ticket [2840](https://sourceforge.net/p/flightgear/codetickets/2840/) regarding error discussion (Maybe the filter clamping the error prop can be removed)

----

Refs:
- https://www.youtube.com/watch?v=hVsx4XWafXg Gyroscopic Instruments
- https://m.youtube.com/watch?v=9EZ9ZI8kAWM Operation And Errors Of Directional Gyro Indicator | Lecture 27
- https://www.youtube.com/watch?v=q1TVR9xdl64 The Heading Indicator (Directional Gyro)
- Mailing list discussion: https://sourceforge.net/p/flightgear/mailman/flightgear-devel/thread/6e66f08e3fb3f02a9d5c557cfd7a2910%40hallinger.org/#msg53245268
- FGFS Wiki Newsletter Jan/2024: https://wiki.flightgear.org/FlightGear_Newsletter_January_2024#Gyro_based_instruments_enhancements (with more info)
- C172 sister ticket: https://github.com/c172p-team/c172p/pull/1490
