### PR TITLE
Issue525 save dg offset (by storing offset with simple DG implementation)

### DIFF
--- a/Models/Instruments/hi.xml
+++ b/Models/Instruments/hi.xml
@@ -130,7 +130,7 @@
   <animation>
     <type>rotate</type>
     <object-name>OBS-Knob</object-name>
-     <property>instrumentation/heading-indicator/offset-deg</property>
+     <property>instrumentation/heading-indicator/align-deg</property>
 <factor>10</factor>
 		<center>
 			<x-m>0.012842</x-m>
@@ -183,6 +183,14 @@
       <binding>
         <command>property-adjust</command>
         <property>instrumentation/heading-indicator/offset-deg</property>
+        <factor>1</factor>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
+        <command>property-adjust</command>
+        <property>instrumentation/heading-indicator/align-deg</property>
         <factor>1</factor>
         <min>0</min>
         <max>360</max>
@@ -362,6 +370,14 @@
         <wrap>1</wrap>
       </binding>
       <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/align-deg</property>
+        <step>1</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
         <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
@@ -373,6 +389,14 @@
       <binding>
         <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/offset-deg</property>
+        <step>5</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>5</step>
         <min>0</min>
         <max>360</max>
@@ -396,6 +420,14 @@
         <wrap>1</wrap>
       </binding>
       <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/align-deg</property>
+        <step>-1</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
         <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
@@ -407,6 +439,14 @@
       <binding>
         <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/offset-deg</property>
+        <step>1</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>1</step>
         <min>0</min>
         <max>360</max>
@@ -445,6 +485,14 @@
         <wrap>1</wrap>
       </binding>
       <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/align-deg</property>
+        <step>-1</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
         <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
@@ -456,6 +504,14 @@
       <binding>
         <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/offset-deg</property>
+        <step>-5</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/align-deg</property>
         <step>-5</step>
         <min>0</min>
         <max>360</max>
@@ -479,6 +535,14 @@
         <wrap>1</wrap>
       </binding>
       <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/align-deg</property>
+        <step>-1</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
         <command>nasal</command>
         <script>c182s.click("heading-offset-dial")</script>
       </binding>
@@ -490,6 +554,14 @@
       <binding>
         <command>property-adjust</command>
         <property>/instrumentation/heading-indicator/offset-deg</property>
+        <step>1</step>
+        <min>0</min>
+        <max>360</max>
+        <wrap>1</wrap>
+      </binding>
+      <binding>
+        <command>property-adjust</command>
+        <property>/instrumentation/heading-indicator/aign-deg</property>
         <step>1</step>
         <min>0</min>
         <max>360</max>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -1070,6 +1070,7 @@
             <path>/instrumentation/attitude-indicator/horizon-offset-deg</path>
             <path>/instrumentation/airspeed-indicator/tas-face-rotation</path>
             <path>/instrumentation/heading-indicator/offset-deg</path>
+            <path>/instrumentation/heading-indicator/align-deg</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -970,6 +970,7 @@
             <path>/instrumentation/attitude-indicator/horizon-offset-deg</path>
             <path>/instrumentation/airspeed-indicator/tas-face-rotation</path>
             <path>/instrumentation/heading-indicator/offset-deg</path>
+            <path>/instrumentation/heading-indicator/align-deg</path>
             <path>/autopilot/settings/heading-bug-deg</path>
             <path>/instrumentation/transponder/id-code</path>
             <path>/instrumentation/transponder/factory-vfr-code</path>


### PR DESCRIPTION
DG/HI: add "align" property, so knob does not rotate with precession

This is based on FGF SF ticket 2838 (https://sourceforge.net/p/flightgear/codetickets/2838/) for the precession to actually apply to the DG.

If applied, should be compatible to PR https://github.com/HHS81/c182s/pull/527
Also, this is downward compatible to older versions, so could be applied also without the SF ticket already.

Fix #525