### PR TITLE
Starter overheating simulation

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -32,6 +32,7 @@ To prevent this, you should apply the plane cover when securing your craft.
 Unchecking `Complex engine procedures and failures` allows a fairly basic engine mode where no priming is needed (just activate
 battery, apply enough mixture and press `s` to start), and no further damage can occur.  
 Otherwise you need to pay attention to varios engine related things:
+
 - Priming for startup  
   The priming procedure involves applying some fuel into the manifold by the fuel pump. The exact procedure is laid out in the checklist.
   The engine can be easily flooded, especially in cold weather (remedy actions also in the POH/Checklist).
@@ -58,6 +59,8 @@ Otherwise you need to pay attention to varios engine related things:
   engine at 1200 RPM. Should a magneto check reveal spark plug problems, its most of the time some fouled plugs. Put the engine to 1800 RPM and 50°
   lean of peak EGT. Let it run for about 30 seconds, monitor CHT. This should clean the deposits which a second magneto check should verify.  
 When parking the plane after flight, you should go to 1800 RPM and lean mix for 20 secs, then reduce throttle to 1000 RPM and then stop the engine by pulling mixture to the cut-off position.
+- `Allow starter cycle limits`  
+  If active, you need to observe the starter cycle, otherwise you risk burning trough the engine starter.
 - `Winter Kit`  
   The winter kit is needed in cold weather (<20°F/-6°C) to reduce cooling air flow. If not supplied, the engine will possibly not get warm enough to develop good power, but be sure to remove it in hot weather, otherwise you risk too high CHT temps.
 

--- a/Nasal/c182s-electrical.nas
+++ b/Nasal/c182s-electrical.nas
@@ -327,8 +327,10 @@ update_virtual_bus = func( dt ) {
 
     # starter motor
     var starter_switch = getprop("controls/switches/starter");
+    var starter_svc    = getprop("/engines/engine/starter/serviceable");
+    var starter_molten = getprop("/engines/engine/starter/overheated");
     var starter_volts = 0.0;
-    if ( starter_switch ) {
+    if ( starter_switch and starter_svc and !starter_molten ) {
         starter_volts = bus_volts;
         load += 22;
     }

--- a/Nasal/c182t-electrical.nas
+++ b/Nasal/c182t-electrical.nas
@@ -352,8 +352,10 @@ update_virtual_bus = func( dt ) {
 
     # starter motor
     var starter_switch = getprop("controls/switches/starter");
+    var starter_svc    = getprop("/engines/engine/starter/serviceable");
+    var starter_molten = getprop("/engines/engine/starter/overheated");
     var starter_volts = 0.0;
-    if ( starter_switch ) {
+    if ( starter_switch and starter_svc and !starter_molten ) {
         starter_volts = bus_volts;
         load += 22;
     }

--- a/Nasal/custom-failures.nas
+++ b/Nasal/custom-failures.nas
@@ -398,6 +398,10 @@ customFailures_c182common = [
         trigger:  MtbfTrigger.new(0)
     },
     
+    {id:"engine/starter", name:"Starter",
+        actuator: set_unserviceable_abs("/engines/engine[0]/starter/serviceable"),
+        trigger:  MtbfTrigger.new(0)
+    },
     
     {id:"engine/magnetos", name:"Magnetos",
         actuator: fail_random_magnetos(),

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -765,4 +765,101 @@
         <output>/engines/engine[0]/governor/serviceable-norm</output>
     </filter>
 
+
+    <!-- Starter overheating -->
+    <filter>
+        <name>Starter temperature</name>
+        <type>noise-spike</type>
+        <!--<debug>true</debug>-->
+        <enable>
+            <condition>
+                <and>
+                    <property>/engines/engine/complex-engine-procedures</property>
+                    <property>/engines/engine/starter-management</property>
+                </and>
+            </condition>
+        </enable>
+        <initialize-to>input</initialize-to>
+        
+        <!-- Init / repairing: allow temp value to sdrop rapidly -->
+        <max-rate-of-change>
+            <condition>
+                <and>
+                    <not><property>/controls/engines/engine[0]/starter</property></not>
+                    <or>
+                        <property>/fdm/jsbsim/damage/repairing</property>
+                        <less-than>
+                            <property>/sim/time/elapsed-sec</property>
+                            <value>5.0</value>
+                        </less-than>
+                    </or>
+                </and>
+            </condition>
+            <expression>
+                <value>250.0</value>
+            </expression>
+        </max-rate-of-change>
+
+        <!-- starter engaged: heat up -->
+        <max-rate-of-change>
+            <condition>
+                <property>/controls/engines/engine[0]/starter</property>
+            </condition>
+            <expression>
+                <value>3.5</value> <!-- deg/second -->
+            </expression>
+        </max-rate-of-change>
+        <input>
+            <condition>
+                <property>/controls/engines/engine[0]/starter</property>
+            </condition>
+            <value>300</value>
+        </input>
+        
+        <!-- starter inactive: cooldown -->
+        <max-rate-of-change>
+            <expression>
+                <value>1.0</value> <!-- deg/second -->
+            </expression>
+        </max-rate-of-change>
+        <input>
+            <expression>
+                <product>
+                    <difference>
+                        <property>/engines/engine/cowling-air-temperature-degf</property>
+                        <value>32</value>
+                    </difference>
+                    <value>0.556</value>
+                </product>
+            </expression>
+        </input>
+        <output>/engines/engine[0]/starter/temperature-degc</output>
+    </filter>
+    <logic>
+        <name>Starter overheated</name>
+        <input>
+            <and>
+                <property>/engines/engine/complex-engine-procedures</property>
+                <property>/engines/engine/starter-management</property>
+                <or>
+                    <and> <!-- if it was molten, keep it molten - unless we repair -->
+                        <property>/engines/engine[0]/starter/overheated</property>
+                        <not><property>/fdm/jsbsim/damage/repairing</property></not>
+                    </and>
+                    
+                    <and> <!-- if starter is engaging and exceeding critical temp, melt down -->
+                        <property>/controls/engines/engine[0]/starter</property>
+                        <greater-than-equals>
+                            <property>/engines/engine[0]/starter/temperature-degc</property>
+                            <value>100</value> <!-- critical temp -->
+                        </greater-than-equals>
+                    </and>
+                </or>
+            </and>
+        </input>
+        <output>
+            <property>/engines/engine[0]/starter/overheated</property>
+        </output>
+    </logic>
+    
 </PropertyList>

--- a/c182s-set.xml
+++ b/c182s-set.xml
@@ -959,6 +959,7 @@
             <path>/engines/engine/allow-fuel-contamination</path>
             <path>/engines/engine/allow-oil-management</path>
             <path>/engines/engine/allow-sparkplug-icing</path>
+            <path>/engines/engine/starter-management</path>
             <path>/engines/engine/winter-kit-installed</path>
             
             <path>/fdm/jsbsim/settings/damage</path>
@@ -1331,6 +1332,7 @@
    <complex-engine-procedures type="bool">false</complex-engine-procedures>
    <allow-fuel-contamination type="bool">false</allow-fuel-contamination>
    <allow-oil-management type="bool">false</allow-oil-management>
+   <starter-management type="bool">false</starter-management>
    <winter-kit-installed type="bool">false</winter-kit-installed>
    <oil-grade>15W-50</oil-grade>
    <oil-temperature-env-diff type="double">0</oil-temperature-env-diff>
@@ -1354,6 +1356,9 @@
    <governor>
         <serviceable type="bool">true</serviceable>
     </governor>
+    <starter>
+      <serviceable type="bool">true</serviceable>
+    </starter>
     <manual-roughness-factor type="double">0</manual-roughness-factor>
     <manual-power-reduction-pct type="double">0</manual-power-reduction-pct>
   

--- a/c182t-set.xml
+++ b/c182t-set.xml
@@ -873,6 +873,7 @@
             <path>/engines/engine/allow-fuel-contamination</path>
             <path>/engines/engine/allow-oil-management</path>
             <path>/engines/engine/allow-sparkplug-icing</path>
+            <path>/engines/engine/starter-management</path>
             <path>/engines/engine/winter-kit-installed</path>
 
             <path>/fdm/jsbsim/settings/damage</path>
@@ -1227,6 +1228,7 @@
    <allow-fuel-contamination type="bool">false</allow-fuel-contamination>
    <allow-oil-management type="bool">false</allow-oil-management>
    <allow-sparkplug-icing type="bool">false</allow-sparkplug-icing>
+   <starter-management type="bool">false</starter-management>
    <winter-kit-installed type="bool">false</winter-kit-installed>
    <oil-grade>15W-50</oil-grade>
    <oil-temperature-env-diff type="double">0</oil-temperature-env-diff>
@@ -1249,6 +1251,9 @@
    <governor>
         <serviceable type="bool">true</serviceable>
     </governor>
+    <starter>
+      <serviceable type="bool">true</serviceable>
+    </starter>
     <manual-roughness-factor type="double">0</manual-roughness-factor>
     <manual-power-reduction-pct type="double">0</manual-power-reduction-pct>
     

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -276,6 +276,35 @@
                 <empty><stretch>true</stretch></empty> <!-- force group to the left -->
             </group>
 
+            <group>
+                <layout>hbox</layout>
+                <!-- Small left padding -->
+                <group>
+                    <layout>vbox</layout>
+                    <padding>6</padding>
+                </group>
+                
+                <group>
+                    <layout>hbox</layout>
+                    <checkbox>
+                        <halign>left</halign>
+                        <label>  Allow starter cycle limits</label>
+                        <property>/engines/engine/starter-management</property>
+                        <live>true</live>
+                        <enable>
+                            <and>
+                                <property>/engines/engine/complex-engine-procedures</property>
+                            </and>
+                        </enable>
+                        <binding>
+                            <command>dialog-apply</command>
+                        </binding>
+                    </checkbox>
+                </group>
+                
+                <empty><stretch>true</stretch></empty> <!-- force group to the left -->
+            </group>
+            
         </group>
         
         <checkbox>

--- a/gui/dialogs/c182-extendedFailures.xml
+++ b/gui/dialogs/c182-extendedFailures.xml
@@ -369,6 +369,23 @@
         <col>2</col>
         <property>/sim/failure-manager/engine/governor/mtbf</property>
       </input>
+      
+      <text>
+        <row>2</row>
+        <col>3</col>
+        <halign>right</halign>
+        <label>Engine starter</label>
+      </text>
+      <checkbox>
+        <row>2</row>
+        <col>4</col>
+        <property>/sim/failure-manager/engine/starter/serviceable</property>
+      </checkbox>
+      <input>
+        <row>2</row>
+        <col>5</col>
+        <property>/sim/failure-manager/engine/starter/mtbf</property>
+      </input>
 
       <!--
       <text>


### PR DESCRIPTION
The simulation is very basic, but I think good enough for that usecase.

You can crank the engine about 30 seconds (depending on OAT) before the starter melts.
The POH starter cycle (10s crank, 20s cooldown; then repeatable 2 times, then cooldown for 10 mins) is OK in warm weather (however not anymore in _very_ hot temps!).

It's implemented optional (-> aircraft menu) and defaults to off.

Fix #567