### PR TITLE
Rudder: made more unsensitive

### DIFF
--- a/c182s.xml
+++ b/c182s.xml
@@ -2108,6 +2108,7 @@
                     <table>
                         <independentVar>velocities/u-fps</independentVar>
                         <tableData>
+                                0.0   0.0000
                               107.1  -0.0604 	 <!--Approach-->
                               133.5  -0.0645 <!--climb-->
                               220.1   -0.0805 	 <!--cruise-->

--- a/c182s.xml
+++ b/c182s.xml
@@ -943,8 +943,22 @@
   </channel>
   
         <channel name="Yaw">
-            <summer name="Yaw Trim Sum">
+            <kinematic name="fcs/rudder-cmd-norm-filtered">
                 <input>fcs/rudder-cmd-norm</input>
+                <traverse>
+                    <setting>
+                        <position>-1</position>
+                        <time>0</time>
+                    </setting>
+                    <setting>
+                        <position>1</position>
+                        <time>0.15</time>
+                    </setting>
+                </traverse>
+            </kinematic>
+            
+            <summer name="Yaw Trim Sum">
+                <input>fcs/rudder-cmd-norm-filtered</input>
                 <input>fcs/yaw-trim-cmd-norm</input>
                 <clipto>
                     <min>-1</min>

--- a/c182t.xml
+++ b/c182t.xml
@@ -2107,6 +2107,7 @@
                     <table>
                         <independentVar>velocities/u-fps</independentVar>
                         <tableData>
+                                0.0   0.0000
                               107.1  -0.0604 	 <!--Approach-->
                               133.5  -0.0645 <!--climb-->
                               220.1   -0.0805 	 <!--cruise-->

--- a/c182t.xml
+++ b/c182t.xml
@@ -943,8 +943,22 @@
   </channel>
   
         <channel name="Yaw">
-            <summer name="Yaw Trim Sum">
+            <kinematic name="fcs/rudder-cmd-norm-filtered">
                 <input>fcs/rudder-cmd-norm</input>
+                <traverse>
+                    <setting>
+                        <position>-1</position>
+                        <time>0</time>
+                    </setting>
+                    <setting>
+                        <position>1</position>
+                        <time>0.15</time>
+                    </setting>
+                </traverse>
+            </kinematic>
+            
+            <summer name="Yaw Trim Sum">
+                <input>fcs/rudder-cmd-norm-filtered</input>
                 <input>fcs/yaw-trim-cmd-norm</input>
                 <clipto>
                     <min>-1</min>


### PR DESCRIPTION
Adjust rudder effect:
- On slow speeds, the rudder now does not have a base effect.
  This essentially makes the nose wheel the only effective force source for steering, unless the rudder gets enough wind to be effective. Before this, the rudder always had some effect.
- Added a damping kinematic for rudder traversal.
  This is not significant or big, but helps filter out jitter/fast movements of analog rudder pedals (aka joystick)

As a result, the rudder gets more mushy on very low speeds and it thus takes more right rudder for takeoff.
But I think the right-rudder that was needed before was a) too sensitive and b) too few.