### PR TITLE
Issue 580 / Dialog header closing button: "X" Added

### DIFF
--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -40,14 +40,15 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>
-	</button>
+        </button>
 	</group>
 	<hrule/>
     

--- a/gui/dialogs/c182-about.xml
+++ b/gui/dialogs/c182-about.xml
@@ -28,10 +28,11 @@
         </text>
         <empty><stretch>true</stretch></empty>
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182-about.xml
+++ b/gui/dialogs/c182-about.xml
@@ -158,6 +158,17 @@
         <default-padding>6</default-padding>
 
         <button>
+            <halign>center</halign>
+            <legend>Documentation</legend>
+            <binding>
+                <command>dialog-show</command>
+                <dialog-name type="string">c182-documentation-dialog</dialog-name>
+            </binding>
+        </button>
+        
+        <vrule/>
+        
+        <button>
             <halign>left</halign>
             <legend>Wiki Page</legend>
             <binding>

--- a/gui/dialogs/c182-documentation.xml
+++ b/gui/dialogs/c182-documentation.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+
+<!-- c182s documentation dialog
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License as
+ published by the Free Software Foundation; either version 2 of the
+ License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+-->
+
+<PropertyList>
+
+    <name>c182-documentation-dialog</name>
+    <layout>vbox</layout>
+    <resizable>true</resizable>
+    <modal>false</modal>
+    <draggable>true</draggable>
+    
+    <nasal>
+        <open><![CDATA[
+            # Load documentation.md
+            var filename = getprop("/sim/aircraft-dir/")~"/Documentation.md";
+            var file_content=io.readfile(filename);
+            setprop("/sim/documentation/c182/aircraft-documentation_sourcefile", filename);
+            setprop("/sim/documentation/c182/aircraft-documentation", file_content);
+            # TODO: parse markdown and show formatting via canvas?
+        ]]></open>
+    </nasal>
+
+    <group>
+        <layout>hbox</layout>
+        <empty><stretch>true</stretch></empty>
+        <text>
+            <label>Documentation</label>
+        </text>
+        <empty><stretch>true</stretch></empty>
+        <button>
+            <legend>X</legend>
+            <key>Esc</key>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
+    <hrule/>
+
+    <group>
+        <layout>vbox</layout>
+        <default-padding>6</default-padding>
+        <text>
+            <halign>left</halign>
+            <label>MMMMMMMMMM</label>
+            <format>%s:</format>
+            <property>/sim/documentation/c182/aircraft-documentation_sourcefile</property>
+        </text>
+        <textbox>
+            <name>basic description</name>
+            <halign>fill</halign>
+            <stretch>true</stretch>
+            <pref-width>1000</pref-width>
+            <pref-height>800</pref-height>
+            <editable>false</editable>
+            <wrap>true</wrap>
+            <live>false</live>
+            <top-line>0</top-line>
+            <property>/sim/documentation/c182/aircraft-documentation</property>
+        </textbox>
+    </group>
+    
+</PropertyList>

--- a/gui/dialogs/c182-extendedFailures.xml
+++ b/gui/dialogs/c182-extendedFailures.xml
@@ -34,11 +34,11 @@
     <empty><stretch>1</stretch></empty>
 
     <button>
-      <pref-width>16</pref-width>
-      <pref-height>16</pref-height>
-      <legend></legend>
-      <keynum>27</keynum>
-      <border>2</border>
+      <legend>X</legend>
+      <key>Esc</key>
+      <halign>right</halign>
+      <pref-width>20</pref-width>
+      <pref-height>20</pref-height>
       <binding>
         <command>dialog-close</command>
       </binding>

--- a/gui/dialogs/c182s-baggage-weight.xml
+++ b/gui/dialogs/c182s-baggage-weight.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-fuel-selector.xml
+++ b/gui/dialogs/c182s-fuel-selector.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-fuel-strainer.xml
+++ b/gui/dialogs/c182s-fuel-strainer.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-left-fuel-drain.xml
+++ b/gui/dialogs/c182s-left-fuel-drain.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-left-fuel.xml
+++ b/gui/dialogs/c182s-left-fuel.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-oil.xml
+++ b/gui/dialogs/c182s-oil.xml
@@ -20,10 +20,11 @@
             <stretch>true</stretch>
         </empty>
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-right-fuel-drain.xml
+++ b/gui/dialogs/c182s-right-fuel-drain.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-right-fuel.xml
+++ b/gui/dialogs/c182s-right-fuel.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-states.xml
+++ b/gui/dialogs/c182s-states.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c182s-wheel-nose.xml
+++ b/gui/dialogs/c182s-wheel-nose.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/damage-overview.xml
+++ b/gui/dialogs/damage-overview.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/fuel.xml
+++ b/gui/dialogs/fuel.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/ground-equipement.xml
+++ b/gui/dialogs/ground-equipement.xml
@@ -31,14 +31,15 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>
-	</button>
+        </button>
 	</group>
 	<hrule/>
     

--- a/gui/dialogs/immat.xml
+++ b/gui/dialogs/immat.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/securing.xml
+++ b/gui/dialogs/securing.xml
@@ -31,14 +31,15 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>
-	</button>
+        </button>
 	</group>
 	<hrule/>
     


### PR DESCRIPTION
- Adding "X" to the dialog close button in the windows header
- Added "Documentation" button to "about" dialog, which displays the content of the local Documentation.md file