### PR TITLE
Welcome dialog for new pilots

### DIFF
--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -1217,7 +1217,11 @@ setlistener("/sim/signals/fdm-initialized", func {
         "Check out the 'Aircraft Options' menu to activate more realism and features.\n" ~
         "Refer to the 'Aircraft Help' menu to access the checklist and keybinds.\n" ~
         "The 'About' dialog has more infos and links to further documentation.\n" ~
-        "\n\n...and now: always blue skies!",
+        "\n" ~
+        "When you have suggestions or want to report a bug, just kindly open a ticket at\n" ~
+        "the GitHub project site: https://github.com/HHS81/c182s \n" ~
+        "\n" ~
+        "\n...and now: always blue skies!",
         nil,
         canvas.MessageBox.Ok | canvas.MessageBox.DontShowAgain,
         [700, 470]

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -1223,8 +1223,7 @@ setlistener("/sim/signals/fdm-initialized", func {
         "\n" ~
         "\n...and now: always blue skies!",
         nil,
-        canvas.MessageBox.Ok | canvas.MessageBox.DontShowAgain,
-        [700, 470]
+        canvas.MessageBox.Ok | canvas.MessageBox.DontShowAgain
     );
 
 });

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -1201,6 +1201,25 @@ setlistener("/sim/signals/fdm-initialized", func {
 
     # Handle realism settings
     setlistener("/sim/realism/instruments/realistic-instruments", setRealismInstruments, 1, 0);
+    
+    # Show a welcome dialog for first time users
+    canvas.MessageBox.information(
+        "Welcome!",
+        "We wish you alot of fun with your new Cessna 182!\n" ~
+        "If you step up from the C172, you will appreciate the bigger engine and faster speed,\n" ~
+        "while still getting the familiar and gently Cessna feeling (albeit it is more sensitive!).\n" ~
+        "\n" ~
+        "If you load this plane the first time, not all features are enabled and you won't get\n" ~
+        "the most realistic simulation possible. The C182 has alot of enhanced features and\n" ~
+        "can (should) be flown according to the Pilots operating Handbook (POH).\n" ~
+        "Check out the 'Aircraft Options' menu to activate more realism and features.\n" ~
+        "Refer to the 'Aircraft Help' menu to access the checklist and keybinds.\n" ~
+        "The 'About' dialog has more infos and links to further documentation.\n" ~
+        "\n\n...and now: always blue skies!",
+        nil,
+        canvas.MessageBox.Ok | canvas.MessageBox.DontShowAgain,
+        [700, 400]
+    );
 
 });
 

--- a/Nasal/c182s.nas
+++ b/Nasal/c182s.nas
@@ -1204,10 +1204,12 @@ setlistener("/sim/signals/fdm-initialized", func {
     
     # Show a welcome dialog for first time users
     canvas.MessageBox.information(
-        "Welcome!",
-        "We wish you alot of fun with your new Cessna 182!\n" ~
-        "If you step up from the C172, you will appreciate the bigger engine and faster speed,\n" ~
-        "while still getting the familiar and gently Cessna feeling (albeit it is more sensitive!).\n" ~
+        "Welcome!\n",
+        "We wish you alot of fun with your new Cessna 182!\n\n" ~
+        "If you step up from the C172, you will appreciate the bigger engine and the higher " ~
+        "power that come with that - all while still getting the familiar and gently Cessna feeling.\n" ~
+        "The C182 is more sensitive and features a constant speed propeller, which need some " ~
+        "time to get used to - but the higher service ceiling and bigger endurance will pay off quickly.\n" ~
         "\n" ~
         "If you load this plane the first time, not all features are enabled and you won't get\n" ~
         "the most realistic simulation possible. The C182 has alot of enhanced features and\n" ~
@@ -1218,7 +1220,7 @@ setlistener("/sim/signals/fdm-initialized", func {
         "\n\n...and now: always blue skies!",
         nil,
         canvas.MessageBox.Ok | canvas.MessageBox.DontShowAgain,
-        [700, 400]
+        [700, 470]
     );
 
 });


### PR DESCRIPTION
Adds a startup message for new pilots:
- briefly introducing the plane
- mentioning where things are to be found
- stating realism settings not enabled by default

![grafik](https://github.com/HHS81/c182s/assets/13608602/56dec3e3-63f1-4014-bdfc-02dd7c896436)


-----
:warning: Needs FGData PR to show nicely:  ~https://sourceforge.net/p/flightgear/codetickets/2879/~
Moved to: https://gitlab.com/flightgear/fgdata/-/work_items/2