### PR TITLE
Use damped gnode for HeadingIndicator gyro

### DIFF
--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -102,6 +102,7 @@ file, these values will be used (they are hardcoded).
     <limits>
       <yaw-limit-rate>11.5</yaw-limit-rate> <!-- about 55° bank, from video footage, see refs in https://github.com/HHS81/c182s/pull/527 -->
       <yaw-error-factor>0.033</yaw-error-factor>
+      <g-node>/accelerations/pilot-gdamped</g-node>
       <g-limit-lower>-0.85</g-limit-lower>
       <g-limit-upper>2.0</g-limit-upper>
       <g-error-factor>0.033</g-error-factor>


### PR DESCRIPTION
The current g-node of the directional gyro is very spike sensitive (for example taxi over hot misplaced taxilane).
This sends the gyro into tumbling mode which is not realistic.

The PR changes this, so we use a filtered g-node.

----
Related to SF ticket #2900 (https://sourceforge.net/p/flightgear/codetickets/2900/)
We need to wait for it to be merged.